### PR TITLE
✨ add trusted users kwarg to bot class

### DIFF
--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -115,8 +115,8 @@ class BotBase(GroupMixin):
         self.owner_ids = options.get('owner_ids', set())
         self.strip_after_prefix = options.get('strip_after_prefix', False)
 
-        self.self_bot = options.pop("self_bot", False)
-        self.trusted_users = options.pop("trusted_users", [])
+        self.self_bot = options.pop('self_bot', False)
+        self.trusted_users = options.pop('trusted_users', [])
 
         if self.owner_id and self.owner_ids:
             raise TypeError('Both owner_id and owner_ids are set.')
@@ -124,6 +124,12 @@ class BotBase(GroupMixin):
         if self.owner_ids and not isinstance(self.owner_ids, collections.abc.Collection):
             raise TypeError(f'owner_ids must be a collection not {self.owner_ids.__class__!r}')
 
+        if self.self_bot and self.trusted_users:
+            raise TypeError('Both self_bot and trusted_users are set.')
+
+        if self.trusted_users and not isinstance(self.trusted_users, collections.abc.Collection):
+            raise TypeError(f'trusted_users must be a collection not {self.trusted_users.__class__!r}')
+            
         if self.trusted_users:
             # skip when the message author is not trusted
             self._skip_check = lambda author, trusted, _: author not in trusted

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -129,17 +129,13 @@ class BotBase(GroupMixin):
 
         if self.trusted_users and not isinstance(self.trusted_users, collections.abc.Collection):
             raise TypeError(f'trusted_users must be a collection not {self.trusted_users.__class__!r}')
-            
-        if self.trusted_users:
-            # skip when the message author is not trusted
+
+        if self.self_bot:
+            self._skip_check = lambda author, _, bot_id: author != bot_id
+        elif self.trusted_users:
             self._skip_check = lambda author, trusted, _: author not in trusted
         else:
-            if self.self_bot:
-                # only trust yourself
-                self._skip_check = lambda author, _, bot_id: author != bot_id
-            else:
-                # anyone but the bot can use commands
-                self._skip_check = lambda author, _, bot_id: author == bot_id
+            self._skip_check = lambda author, _, bot_id: author == bot_id
 
         if help_command is _default:
             self.help_command = DefaultHelpCommand()


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Addition of "trusted_users" kwarg for the Bot class. Allows the selfbotter to choose whom to trust to run commands.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

---

I have not updated the docs but could add an example if requested