### PR TITLE
Check 'verified' before trying to overwrite attributes.

### DIFF
--- a/discord/user.py
+++ b/discord/user.py
@@ -607,6 +607,10 @@ class ClientUser(BaseUser):
 
     def _update(self, data):
         super()._update(data)
+        
+        if not data.get('verified'):
+            return
+        
         self.verified = data.get('verified', False)
         self.email = data.get('email')
         self.phone = data.get('phone')


### PR DESCRIPTION
What causes the problem is that the state coming from a guild overwrites the one already defined in the startup, with that private information is lost.

Fix #77 