### PR TITLE
Made official discord.py library URL open in new tab

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -66,7 +66,7 @@ layout: table_wrappers
       {% endif %}
     </nav>
     <footer class="site-footer">
-      A fork of the popular <a href="//github.com/Rapptz/discord.py">Discord.py</a> for self-bots.
+      A fork of the popular <a href="//github.com/Rapptz/discord.py" target='_blank'>Discord.py</a> for self-bots.
     </footer>
   </div>
   <div class="main" id="top">


### PR DESCRIPTION
## Summary

This pull request makes it so that the 
![image](https://user-images.githubusercontent.com/76237496/154489777-f809b367-f95f-473a-a6d4-72bccc2798eb.png)
URL in the above image (https://github.com/Rapptz/discord.py) opens in a new tab when clicked.

## General Info

- [x] This PR is **not** a code change (e.g. documentation, README, ...)

