### PR TITLE
Make IDENTIFY packet set to DND

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -372,7 +372,7 @@ class DiscordWebSocket:
                 'capabilities': 125,
                 'properties': self._super_properties,
                 'presence': {
-                    'status': 'online',
+                    'status': 'dnd', # TODO: Add a way to automatically detect? - Will leaving this blank keep it the same?
                     'since': 0,
                     'activities': [],
                     'afk': False


### PR DESCRIPTION
## Summary
When sending the IDENTIFY packet through the WebSocket, make it set your status to Do Not Disturb.

## General Info
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [ ] This PR fixes an issue (please put issue # in summary). 
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
