### PR TITLE
Removes unneeded await from `bot.is_owner()` function

### DIFF
--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -2100,7 +2100,7 @@ def is_owner() -> Callable[[T], T]:
     """
 
     async def predicate(ctx: Context) -> bool:
-        if not await ctx.bot.is_owner(ctx.author):
+        if not ctx.bot.is_owner(ctx.author):
             raise NotOwner('You do not own this bot.')
         return True
 


### PR DESCRIPTION
## Summary

Fixes #239.

## General Info

- [x] If code changes were made then they have been tested. 
![image](https://user-images.githubusercontent.com/76237496/158062266-c4d7452b-fa53-4c22-ab0c-fb1ee05f911e.png)
```py
import discord
from discord.ext import commands

bot = commands.Bot(command_prefix="test!", self_bot=False)
bot.owner_ids = [876055467678375998]

@bot.event
async def on_ready():
    print("logged in")

@bot.command()
@commands.is_owner()
async def ping(ctx):
    await ctx.reply(f"Pong, {round(bot.latency, 1)}ms.", mention_author=False)

bot.run()
```
- [x] This PR fixes an issue (please put issue # in summary). 

