### PR TITLE
Fix json being cast to a bool

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -470,7 +470,7 @@ class HTTPClient:
         if reason:
             headers['X-Audit-Log-Reason'] = _uriquote(reason)
 
-        if payload := kwargs.pop('json', None) is not None:
+        if (payload := kwargs.pop('json', None)) is not None:
             headers['Content-Type'] = 'application/json'
             kwargs['data'] = utils._to_json(payload)
 


### PR DESCRIPTION
 
## Summary
Previous code makes payload being a boolean which result in this error, when sending a requests
discord.errors.HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In _errors: [{'code': 'DICT_TYPE_CONVERT', 'message': 'Only dictionaries may be used in a DictType'}]

## General Info 
- [x] If code changes were made then they have been tested. 
- [x] This PR fixes an issue (please put issue # in summary). 
