### PR TITLE
Remove direct discord.utils.MISSING references

### DIFF
--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import inspect
 import discord
-from discord.utils import maybe_coroutine
+from discord.utils import maybe_coroutine,MISSING
 
 from typing import Any, Callable, Dict, Generator, List, Optional, TYPE_CHECKING, Tuple, TypeVar
 
@@ -45,7 +45,6 @@ __all__ = (
 
 FuncT = TypeVar('FuncT', bound=Callable[..., Any])
 
-MISSING: Any = discord.utils.MISSING
 
 
 class CogMeta(type):

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import inspect
-from discord.utils import maybe_coroutine,MISSING
+from discord.utils import maybe_coroutine, MISSING
 
 from typing import Any, Callable, Dict, Generator, List, Optional, TYPE_CHECKING, Tuple, TypeVar
 

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -24,7 +24,6 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import inspect
-import discord
 from discord.utils import maybe_coroutine,MISSING
 
 from typing import Any, Callable, Dict, Generator, List, Optional, TYPE_CHECKING, Tuple, TypeVar

--- a/discord/ext/commands/cog.py
+++ b/discord/ext/commands/cog.py
@@ -45,7 +45,6 @@ __all__ = (
 FuncT = TypeVar('FuncT', bound=Callable[..., Any])
 
 
-
 class CogMeta(type):
     """A metaclass for defining a cog.
 

--- a/discord/ext/commands/context.py
+++ b/discord/ext/commands/context.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, Generic, List, Optio
 
 import discord.abc
 import discord.utils
+from discord.utils import MISSING
 from discord.message import Message
 
 from ._types import BotT
@@ -53,8 +54,6 @@ __all__ = (
     'Context',
 )
 # fmt: on
-
-MISSING: Any = discord.utils.MISSING
 
 
 T = TypeVar('T')

--- a/discord/ext/commands/help.py
+++ b/discord/ext/commands/help.py
@@ -45,6 +45,7 @@ from typing import (
 )
 
 import discord.utils
+from discord.utils import MISSING
 
 from .core import Group, Command, get_signature_parameters
 from .errors import CommandError
@@ -74,8 +75,6 @@ __all__ = (
 )
 
 FuncT = TypeVar('FuncT', bound=Callable[..., Any])
-
-MISSING: Any = discord.utils.MISSING
 
 # help -> shows info of bot on top/bottom and lists subcommands
 # help command -> shows detailed info of command


### PR DESCRIPTION
Changed MISSING imports, because it raises an error when renaming the package 