### PR TITLE
Added a banner color property to BaseUser

### DIFF
--- a/discord/user.py
+++ b/discord/user.py
@@ -240,6 +240,7 @@ class BaseUser(_UserTag):
         '_avatar',
         '_banner',
         '_accent_colour',
+        '_banner_colour',
         'bot',
         'system',
         '_public_flags',
@@ -256,6 +257,7 @@ class BaseUser(_UserTag):
         _avatar: Optional[str]
         _banner: Optional[str]
         _accent_colour: Optional[int]
+        _banner_colour: Optional[int]
         _public_flags: int
 
     def __init__(self, *, state: ConnectionState, data: Union[UserPayload, PartialUserPayload]) -> None:
@@ -287,6 +289,7 @@ class BaseUser(_UserTag):
         self._avatar = data['avatar']
         self._banner = data.get('banner', None)
         self._accent_colour = data.get('accent_color', None)
+        self._banner_colour = data.get('banner_color', None)
         self._public_flags = data.get('public_flags', 0)
         self.bot = data.get('bot', False)
         self.system = data.get('system', False)
@@ -301,6 +304,7 @@ class BaseUser(_UserTag):
         self._avatar = user._avatar
         self._banner = user._banner
         self._accent_colour = user._accent_colour
+        self._banner_colour = user._banner_colour
         self.bot = user.bot
         self._state = user._state
         self._public_flags = user._public_flags
@@ -376,6 +380,39 @@ class BaseUser(_UserTag):
         .. versionadded:: 2.0
         """
         return self.banner
+
+    @property
+    def banner_colour(self) -> Optional[Colour]:
+        """Optional[:class:`Colour`]: Returns the user's banner colour, if applicable.
+
+        There is an alias for this named :attr:`banner_color`.
+
+        .. versionadded:: 2.0
+
+        .. note::
+
+            This information is only available via :meth:`Client.fetch_user`.
+        """
+        if self._banner_colour is None:
+            return None
+        return Colour(self._banner_colour)
+
+    @property
+    def banner_color(self) -> Optional[Colour]:
+        """Optional[:class:`Colour`]: Returns the user's banner color, if applicable.
+
+        There is an alias for this named :attr:`banner_colour`.
+
+        .. versionadded:: 2.0
+
+        .. note::
+
+            This information is only available via :meth:`Client.fetch_user`.
+        """
+        if self._banner_colour is None:
+            return None
+        return Colour(self._banner_colour)
+        
 
     @property
     def accent_colour(self) -> Optional[Colour]:


### PR DESCRIPTION
## Summary
<!-- What is this pull request for? Does it fix any issues? -->
I noticed `BaseUser` does not have a property for banner color, so I added it. This PR has it.

## General Info
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue (please put issue # in summary).
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

## Note
> I have updated the documentation to reflect the changes.

I did add a description string to the property, but I didn't change the actual documentation of the library.