### PR TITLE
Fix ActionRow not implementing "to_dict()"

### DIFF
--- a/discord/components.py
+++ b/discord/components.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from .types.components import (
+        ActionRow as ActionRowPayload,
         Component as ComponentPayload,
         ButtonComponent as ButtonComponentPayload,
         SelectMenu as SelectMenuPayload,
@@ -138,10 +139,11 @@ class ActionRow(Component):
         """:class:`ComponentType`: The type of component."""
         return ComponentType.action_row
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> ActionRowPayload:
+        # NOTE: This will have to be changed for the inevitable selects in modals
         return {
             'type': self.type.value,
-            'components': [c.to_dict() for c in self.children],
+            'components': [c.to_dict() for c in self.children],  # type: ignore
         }
 
 
@@ -294,11 +296,11 @@ class SelectMenu(Component):
         """:class:`ComponentType`: The type of component."""
         return ComponentType.select
 
-    def to_dict(self, options: Tuple[SelectOption]) -> dict:
+    def to_dict(self, options: Optional[Tuple[SelectOption]] = None) -> dict:
         return {
             'component_type': self.type.value,
             'custom_id': self.custom_id,
-            'values': [option.value for option in options],
+            'values': [option.value for option in options] if options else [],
         }
 
     async def choose(self, *options: SelectOption) -> Interaction:

--- a/discord/components.py
+++ b/discord/components.py
@@ -138,6 +138,12 @@ class ActionRow(Component):
         """:class:`ComponentType`: The type of component."""
         return ComponentType.action_row
 
+    def to_dict(self) -> dict:
+        return {
+            'type': self.type.value,
+            'components': [c.to_dict() for c in self.children],
+        }
+
 
 class Button(Component):
     """Represents a button from the Discord Bot UI Kit.


### PR DESCRIPTION
This would make modals impossible to submit, for example

## Summary
This pull request fixes issue #495, which I've found is caused by ActionRow not having to_dict() function implemented.

## General Info
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue (please put issue # in summary).
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
