### PR TITLE
fix for PartialConnection.url property

### DIFF
--- a/discord/connections.py
+++ b/discord/connections.py
@@ -124,15 +124,13 @@ class PartialConnection:
         if self.type == ConnectionType.twitch:
             return f'https://www.twitch.tv/{self.name}'
         elif self.type == ConnectionType.youtube:
-            return f'https://www.youtube.com/{self.id}'
+            return f'https://www.youtube.com/channel/{self.id}'
         elif self.type == ConnectionType.skype:
             return f'skype:{self.id}?userinfo'
         elif self.type == ConnectionType.steam:
             return f'https://steamcommunity.com/profiles/{self.id}'
         elif self.type == ConnectionType.reddit:
             return f'https://www.reddit.com/u/{self.name}'
-        elif self.type == ConnectionType.facebook:
-            return f'https://www.facebook.com/{self.name}'
         elif self.type == ConnectionType.twitter:
             return f'https://twitter.com/{self.name}'
         elif self.type == ConnectionType.spotify:


### PR DESCRIPTION
## Summary
<!-- What is this pull request for? Does it fix any issues? -->

This fixes youtube channel connection URL to give the right channel link, also removed facebook connection URL since we talked about this before on how its URL render fails if fb connection name has spaces in it and how facebook returns different UID for oauth connected apps than actual users UID for privacy reasons etc.

## General Info
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue (please put issue # in summary).
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
