### PR TITLE
Add option to change global display name

### DIFF
--- a/discord/user.py
+++ b/discord/user.py
@@ -40,7 +40,7 @@ from .enums import (
 from .errors import ClientException, NotFound
 from .flags import PublicUserFlags, PrivateUserFlags, PremiumUsageFlags, PurchasedFlags
 from .relationship import Relationship
-from .utils import _bytes_to_base64_data, cached_slot_property, copy_doc, snowflake_time, MISSING
+from .utils import _bytes_to_base64_data, _get_as_snowflake, cached_slot_property, copy_doc, snowflake_time, MISSING
 from .voice_client import VoiceClient
 
 if TYPE_CHECKING:
@@ -58,7 +58,6 @@ if TYPE_CHECKING:
     from .state import ConnectionState
     from .types.channel import DMChannel as DMChannelPayload
     from .types.user import (
-        APIUser as APIUserPayload,
         PartialUser as PartialUserPayload,
         User as UserPayload,
     )
@@ -240,7 +239,6 @@ class BaseUser(_UserTag):
         'name',
         'id',
         'discriminator',
-        'global_name',
         '_avatar',
         '_avatar_decoration',
         '_banner',
@@ -256,7 +254,6 @@ class BaseUser(_UserTag):
         name: str
         id: int
         discriminator: str
-        global_name: Optional[str]
         bot: bool
         system: bool
         _state: ConnectionState
@@ -272,13 +269,11 @@ class BaseUser(_UserTag):
 
     def __repr__(self) -> str:
         return (
-            f"<BaseUser id={self.id} name={self.name!r} global_name={self.global_name!r}"
+            f"<BaseUser id={self.id} name={self.name!r} discriminator={self.discriminator!r}"
             f" bot={self.bot} system={self.system}>"
         )
 
     def __str__(self) -> str:
-        if self.discriminator == '0':
-            return self.name
         return f'{self.name}#{self.discriminator}'
 
     def __eq__(self, other: object) -> bool:
@@ -294,7 +289,6 @@ class BaseUser(_UserTag):
         self.name = data['username']
         self.id = int(data['id'])
         self.discriminator = data['discriminator']
-        self.global_name = data.get('global_name')
         self._avatar = data['avatar']
         self._avatar_decoration = data.get('avatar_decoration')
         self._banner = data.get('banner', None)
@@ -310,7 +304,6 @@ class BaseUser(_UserTag):
         self.name = user.name
         self.id = user.id
         self.discriminator = user.discriminator
-        self.global_name = user.global_name
         self._avatar = user._avatar
         self._avatar_decoration = user._avatar_decoration
         self._banner = user._banner
@@ -322,19 +315,16 @@ class BaseUser(_UserTag):
 
         return self
 
-    def _to_minimal_user_json(self) -> APIUserPayload:
-        user: APIUserPayload = {
+    def _to_minimal_user_json(self) -> PartialUserPayload:
+        user: PartialUserPayload = {
             'username': self.name,
             'id': self.id,
             'avatar': self._avatar,
             'avatar_decoration': self._avatar_decoration,
             'discriminator': self.discriminator,
-            'global_name': self.global_name,
             'bot': self.bot,
             'system': self.system,
             'public_flags': self._public_flags,
-            'banner': self._banner,
-            'accent_color': self._accent_colour,
         }
         return user
 
@@ -361,13 +351,8 @@ class BaseUser(_UserTag):
 
     @property
     def default_avatar(self) -> Asset:
-        """:class:`Asset`: Returns the default avatar for a given user."""
-        if self.discriminator == '0':
-            avatar_id = (self.id >> 22) % 6
-        else:
-            avatar_id = int(self.discriminator) % 5
-
-        return Asset._from_default_avatar(self._state, avatar_id)
+        """:class:`Asset`: Returns the default avatar for a given user. This is calculated by the user's discriminator."""
+        return Asset._from_default_avatar(self._state, int(self.discriminator) % 5)
 
     @property
     def display_avatar(self) -> Asset:
@@ -485,12 +470,10 @@ class BaseUser(_UserTag):
     def display_name(self) -> str:
         """:class:`str`: Returns the user's display name.
 
-        For regular users this is just their global name or their username,
-        but if they have a guild specific nickname then that
+        For regular users this is just their username, but
+        if they have a guild specific nickname then that
         is returned instead.
         """
-        if self.global_name:
-            return self.global_name
         return self.name
 
     @cached_slot_property('_cs_note')
@@ -523,81 +506,6 @@ class BaseUser(_UserTag):
 
         return any(user.id == self.id for user in message.mentions)
 
-    def is_pomelo(self) -> bool:
-        """:class:`bool`: Checks if the user has migrated to Discord's `new unique username system <https://discord.com/blog/usernames>`_
-
-        .. versionadded:: 2.1
-        """
-        return self.discriminator == '0'
-
-    @property
-    def relationship(self) -> Optional[Relationship]:
-        """Optional[:class:`Relationship`]: Returns the :class:`Relationship` with this user if applicable, ``None`` otherwise."""
-        return self._state._relationships.get(self.id)
-
-    def is_friend(self) -> bool:
-        """:class:`bool`: Checks if the user is your friend."""
-        r = self.relationship
-        if r is None:
-            return False
-        return r.type is RelationshipType.friend
-
-    def is_blocked(self) -> bool:
-        """:class:`bool`: Checks if the user is blocked."""
-        r = self.relationship
-        if r is None:
-            return False
-        return r.type is RelationshipType.blocked
-
-    async def profile(
-        self,
-        *,
-        with_mutual_guilds: bool = True,
-        with_mutual_friends_count: bool = False,
-        with_mutual_friends: bool = True,
-    ) -> UserProfile:
-        """|coro|
-
-        A shorthand method to retrieve a :class:`UserProfile` for the user.
-
-        Parameters
-        ------------
-        with_mutual_guilds: :class:`bool`
-            Whether to fetch mutual guilds.
-            This fills in :attr:`UserProfile.mutual_guilds`.
-
-            .. versionadded:: 2.0
-        with_mutual_friends_count: :class:`bool`
-            Whether to fetch the number of mutual friends.
-            This fills in :attr:`UserProfile.mutual_friends_count`.
-
-            .. versionadded:: 2.0
-        with_mutual_friends: :class:`bool`
-            Whether to fetch mutual friends.
-            This fills in :attr:`UserProfile.mutual_friends` and :attr:`UserProfile.mutual_friends_count`,
-            but requires an extra API call.
-
-            .. versionadded:: 2.0
-
-        Raises
-        -------
-        Forbidden
-            Not allowed to fetch this profile.
-        HTTPException
-            Fetching the profile failed.
-
-        Returns
-        --------
-        :class:`UserProfile`
-            The profile of the user.
-        """
-        return await self._state.client.fetch_user_profile(
-            self.id,
-            with_mutual_guilds=with_mutual_guilds,
-            with_mutual_friends_count=with_mutual_friends_count,
-            with_mutual_friends=with_mutual_friends,
-        )
-
 
 class ClientUser(BaseUser):
     """Represents your Discord user.
@@ -618,7 +526,7 @@ class ClientUser(BaseUser):
 
         .. describe:: str(x)
 
-            Returns the user's handle (e.g. ``name`` or ``name#discriminator``).
+            Returns the user's name with discriminator.
 
     .. versionchanged:: 2.0
         :attr:`Locale` is now a :class:`Locale` instead of a Optional[:class:`str`].
@@ -630,13 +538,9 @@ class ClientUser(BaseUser):
     id: :class:`int`
         The user's unique ID.
     discriminator: :class:`str`
-        The user's discriminator. This is a legacy concept that is no longer used.
+        The user's discriminator.
     bio: Optional[:class:`str`]
         The user's "about me" field. Could be ``None``.
-    global_name: Optional[:class:`str`]
-        The user's global nickname, taking precedence over the username in display.
-
-        .. versionadded:: 2.1
     bot: :class:`bool`
         Specifies if the user is a bot account.
     system: :class:`bool`
@@ -647,14 +551,10 @@ class ClientUser(BaseUser):
         Specifies if the user's email is verified.
     email: Optional[:class:`str`]
         The email of the user.
-    phone: Optional[:class:`str`]
+    phone: Optional[:class:`int`]
         The phone number of the user.
 
         .. versionadded:: 1.9
-
-        .. versionchanged:: 2.1
-
-            This now returns a :class:`str` instead of an :class:`int` to match the API.
     mfa_enabled: :class:`bool`
         Specifies if the user has MFA turned on and working.
     premium_type: Optional[:class:`PremiumType`]
@@ -699,7 +599,7 @@ class ClientUser(BaseUser):
     if TYPE_CHECKING:
         verified: bool
         email: Optional[str]
-        phone: Optional[str]
+        phone: Optional[int]
         _locale: str
         _flags: int
         mfa_enabled: bool
@@ -714,15 +614,15 @@ class ClientUser(BaseUser):
 
     def __repr__(self) -> str:
         return (
-            f'<ClientUser id={self.id} name={self.name!r} global_name={self.global_name!r}'
-            f' verified={self.verified} mfa_enabled={self.mfa_enabled} premium={self.premium}>'
+            f'<ClientUser id={self.id} name={self.name!r} discriminator={self.discriminator!r}'
+            f' bot={self.bot} verified={self.verified} mfa_enabled={self.mfa_enabled} premium={self.premium}>'
         )
 
     def _full_update(self, data: UserPayload) -> None:
         self._update(data)
         self.verified = data.get('verified', False)
         self.email = data.get('email')
-        self.phone = data.get('phone')
+        self.phone = _get_as_snowflake(data, 'phone')
         self._locale = data.get('locale', 'en-US')
         self._flags = data.get('flags', 0)
         self._purchased_flags = data.get('purchased_flags', 0)
@@ -776,6 +676,7 @@ class ClientUser(BaseUser):
         self,
         *,
         username: str = MISSING,
+        global_name: str = MISSING,
         avatar: Optional[bytes] = MISSING,
         avatar_decoration: Optional[bytes] = MISSING,
         password: str = MISSING,
@@ -788,7 +689,6 @@ class ClientUser(BaseUser):
         accent_color: Colour = MISSING,
         bio: Optional[str] = MISSING,
         date_of_birth: datetime = MISSING,
-        pomelo: bool = MISSING,
     ) -> ClientUser:
         """|coro|
 
@@ -822,9 +722,11 @@ class ClientUser(BaseUser):
             Could be ``None`` to leave the current house.
         username: :class:`str`
             The new username you wish to change to.
+        global_name: :class:`str`
+            The new global display name you wish to change to.
         discriminator: :class:`int`
             The new discriminator you wish to change to.
-            This is a legacy concept that is no longer used. Can only be used if you have Nitro.
+            Can only be used if you have Nitro.
         avatar: Optional[:class:`bytes`]
             A :term:`py:bytes-like object` representing the image to upload.
             Could be ``None`` to denote no avatar.
@@ -849,23 +751,12 @@ class ClientUser(BaseUser):
             Your date of birth. Can only ever be set once.
 
             .. versionadded:: 2.0
-        pomelo: :class:`bool`
-            Whether to migrate your account to Discord's `new unique username system <https://discord.com/blog/usernames>`_.
-
-            .. note::
-
-                This change cannot be undone and requires you to be in the pomelo rollout.
-
-            .. versionadded:: 2.1
 
         Raises
         ------
         HTTPException
             Editing your profile failed.
-            You are not in the pomelo rollout.
         ValueError
-            Username was not passed when migrating to pomelo.
-            Discriminator was passed when migrated to pomelo.
             Password was not passed when it was required.
             `house` field was not a :class:`HypeSquadHouse`.
             `date_of_birth` field was not a :class:`datetime.datetime`.
@@ -876,17 +767,7 @@ class ClientUser(BaseUser):
         :class:`ClientUser`
             The newly edited client user.
         """
-        state = self._state
         args: Dict[str, Any] = {}
-        data = None
-
-        if pomelo:
-            if not username:
-                raise ValueError('Username is required for pomelo migration')
-            if discriminator:
-                raise ValueError('Discriminator cannot be changed when migrated to pomelo')
-            data = await state.http.pomelo(username)
-            username = MISSING
 
         if any(x is not MISSING for x in (new_password, email, username, discriminator)):
             if password is MISSING:
@@ -919,16 +800,17 @@ class ClientUser(BaseUser):
                 raise ValueError('`accent_colo(u)r` parameter was not a Colour')
             else:
                 args['accent_color'] = accent_color.value
-
+        
         if email is not MISSING:
             args['email'] = email
 
         if username is not MISSING:
             args['username'] = username
 
+        if global_name is not MISSING:
+            args['global_name'] = global_name
+
         if discriminator is not MISSING:
-            if self.is_pomelo():
-                raise ValueError('Discriminator cannot be changed when migrated to pomelo')
             args['discriminator'] = discriminator
 
         if new_password is not MISSING:
@@ -952,12 +834,11 @@ class ClientUser(BaseUser):
             else:
                 await http.change_hypesquad_house(house.value)
 
-        if args or data is None:
-            data = await http.edit_profile(args)
-            try:
-                http._token(data['token'])
-            except KeyError:
-                pass
+        data = await http.edit_profile(args)
+        try:
+            http._token(data['token'])
+        except KeyError:
+            pass
 
         return ClientUser(state=self._state, data=data)
 
@@ -981,7 +862,7 @@ class User(BaseUser, discord.abc.Connectable, discord.abc.Messageable):
 
         .. describe:: str(x)
 
-            Returns the user's handle (e.g. ``name`` or ``name#discriminator``).
+            Returns the user's name with discriminator.
 
     Attributes
     -----------
@@ -990,11 +871,7 @@ class User(BaseUser, discord.abc.Connectable, discord.abc.Messageable):
     id: :class:`int`
         The user's unique ID.
     discriminator: :class:`str`
-        The user's discriminator. This is a legacy concept that is no longer used.
-    global_name: Optional[:class:`str`]
-        The user's global nickname, taking precedence over the username in display.
-
-        .. versionadded:: 2.1
+        The user's discriminator.
     bot: :class:`bool`
         Specifies if the user is a bot account.
     system: :class:`bool`
@@ -1004,7 +881,7 @@ class User(BaseUser, discord.abc.Connectable, discord.abc.Messageable):
     __slots__ = ('__weakref__',)
 
     def __repr__(self) -> str:
-        return f'<User id={self.id} name={self.name!r} global_name={self.global_name!r} bot={self.bot}>'
+        return f'<{self.__class__.__name__} id={self.id} name={self.name!r} discriminator={self.discriminator!r} bot={self.bot} system={self.system}>'
 
     def _get_voice_client_key(self) -> Tuple[int, str]:
         return self._state.self_id, 'self_id'  # type: ignore # self_id is always set at this point
@@ -1024,18 +901,10 @@ class User(BaseUser, discord.abc.Connectable, discord.abc.Messageable):
             user['discriminator'],
             user.get('public_flags', 0),
             user.get('avatar_decoration'),
-            user.get('global_name'),
         )
         if original != modified:
             to_return = User._copy(self)
-            (
-                self.name,
-                self._avatar,
-                self.discriminator,
-                self._public_flags,
-                self._avatar_decoration,
-                self.global_name,
-            ) = modified
+            self.name, self._avatar, self.discriminator, self._public_flags, self._avatar_decoration = modified
             # Signal to dispatch user_update
             return to_return, self
 
@@ -1056,6 +925,11 @@ class User(BaseUser, discord.abc.Connectable, discord.abc.Messageable):
     def call(self) -> Optional[PrivateCall]:
         """Optional[:class:`PrivateCall`]: Returns the call associated with this user if it exists."""
         return getattr(self.dm_channel, 'call', None)
+
+    @property
+    def relationship(self) -> Optional[Relationship]:
+        """Optional[:class:`Relationship`]: Returns the :class:`Relationship` with this user if applicable, ``None`` otherwise."""
+        return self._state._relationships.get(self.id)
 
     @copy_doc(discord.abc.Connectable.connect)
     async def connect(
@@ -1093,7 +967,21 @@ class User(BaseUser, discord.abc.Connectable, discord.abc.Messageable):
         data: DMChannelPayload = await state.http.start_private_message(self.id)
         return state.add_dm_channel(data)
 
-    async def block(self) -> None:
+    def is_friend(self) -> bool:
+        """:class:`bool`: Checks if the user is your friend."""
+        r = self.relationship
+        if r is None:
+            return False
+        return r.type is RelationshipType.friend
+
+    def is_blocked(self) -> bool:
+        """:class:`bool`: Checks if the user is blocked."""
+        r = self.relationship
+        if r is None:
+            return False
+        return r.type is RelationshipType.blocked
+
+    async def block(self) -> None:  # TODO: maybe return relationship
         """|coro|
 
         Blocks the user.
@@ -1149,4 +1037,53 @@ class User(BaseUser, discord.abc.Connectable, discord.abc.Messageable):
         HTTPException
             Sending the friend request failed.
         """
-        await self._state.http.add_relationship(self.id, action=RelationshipAction.send_friend_request)
+        await self._state.http.send_friend_request(self.name, self.discriminator)
+
+    async def profile(
+        self,
+        *,
+        with_mutual_guilds: bool = True,
+        with_mutual_friends_count: bool = False,
+        with_mutual_friends: bool = True,
+    ) -> UserProfile:
+        """|coro|
+
+        A shorthand method to retrieve a :class:`UserProfile` for the user.
+
+        Parameters
+        ------------
+        with_mutual_guilds: :class:`bool`
+            Whether to fetch mutual guilds.
+            This fills in :attr:`UserProfile.mutual_guilds`.
+
+            .. versionadded:: 2.0
+        with_mutual_friends_count: :class:`bool`
+            Whether to fetch the number of mutual friends.
+            This fills in :attr:`UserProfile.mutual_friends_count`.
+
+            .. versionadded:: 2.0
+        with_mutual_friends: :class:`bool`
+            Whether to fetch mutual friends.
+            This fills in :attr:`UserProfile.mutual_friends` and :attr:`UserProfile.mutual_friends_count`,
+            but requires an extra API call.
+
+            .. versionadded:: 2.0
+
+        Raises
+        -------
+        Forbidden
+            Not allowed to fetch this profile.
+        HTTPException
+            Fetching the profile failed.
+
+        Returns
+        --------
+        :class:`UserProfile`
+            The profile of the user.
+        """
+        return await self._state.client.fetch_user_profile(
+            self.id,
+            with_mutual_guilds=with_mutual_guilds,
+            with_mutual_friends_count=with_mutual_friends_count,
+            with_mutual_friends=with_mutual_friends,
+        )

--- a/discord/user.py
+++ b/discord/user.py
@@ -776,7 +776,7 @@ class ClientUser(BaseUser):
         self,
         *,
         username: str = MISSING,
-        global_name: str = MISSING,
+        global_name: Optional[str] = MISSING,
         avatar: Optional[bytes] = MISSING,
         avatar_decoration: Optional[bytes] = MISSING,
         password: str = MISSING,
@@ -813,7 +813,7 @@ class ClientUser(BaseUser):
         -----------
         password: :class:`str`
             The current password for the client's account.
-            Required for everything except avatar, banner, accent_colour, date_of_birth, and bio.
+            Required for everything except avatar, banner, accent_colour, date_of_birth, global_name, and bio.
         new_password: :class:`str`
             The new password you wish to change to.
         email: :class:`str`
@@ -823,8 +823,6 @@ class ClientUser(BaseUser):
             Could be ``None`` to leave the current house.
         username: :class:`str`
             The new username you wish to change to.
-        global_name: :class:`str`
-            The new global display name you wish to change to.
         discriminator: :class:`int`
             The new discriminator you wish to change to.
             This is a legacy concept that is no longer used. Can only be used if you have Nitro.
@@ -860,7 +858,10 @@ class ClientUser(BaseUser):
                 This change cannot be undone and requires you to be in the pomelo rollout.
 
             .. versionadded:: 2.1
+        global_name: Optional[:class:`str`]
+            The new global display name you wish to change to.
 
+            .. versionadded:: 2.1
         Raises
         ------
         HTTPException

--- a/discord/user.py
+++ b/discord/user.py
@@ -862,6 +862,7 @@ class ClientUser(BaseUser):
             The new global display name you wish to change to.
 
             .. versionadded:: 2.1
+
         Raises
         ------
         HTTPException


### PR DESCRIPTION
## Summary
Added the ability to change the global display name (the name that shows up for everybody that takes precedence over your actual @username) for the discord.ClientUser class.

## General Info
A very simple addition to the base library. There is no need for a captcha/password when changing your display name. I did my best to keep the style of this pull request consistent with the style of the rest of the library.

There are two commits instead of one for this pull request since the original commit was made to the PyPi version of this library. The second and most recent commit uses the code presently found in the main branch.