### PR TITLE
Fix fallback build number retrieval

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1479,7 +1479,8 @@ async def _get_build_number(session: ClientSession) -> int:  # Thank you Discord
         build_url = 'https://discord.com/assets/' + re.compile(r'assets/+([a-z0-9]+)\.js').findall(login_page)[-2] + '.js'
         build_request = await session.get(build_url, timeout=7)
         build_file = await build_request.text()
-        build_index = build_file.find('buildNumber') + 24
+        build_find = 'Build Number: ").concat("'
+        build_index = build_file.find(build_find) + len(build_find)
         return int(build_file[build_index : build_index + 6])
     except asyncio.TimeoutError:
         _log.critical('Could not fetch client build number. Falling back to hardcoded value...')

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1473,6 +1473,7 @@ async def _get_info(session: ClientSession) -> Tuple[Dict[str, Any], str]:
 
 async def _get_build_number(session: ClientSession) -> int:  # Thank you Discord-S.C.U.M
     """Fetches client build number"""
+    default_build_number = 9999
     try:
         login_page_request = await session.get('https://discord.com/login', timeout=7)
         login_page = await login_page_request.text()
@@ -1480,10 +1481,10 @@ async def _get_build_number(session: ClientSession) -> int:  # Thank you Discord
         build_request = await session.get(build_url, timeout=7)
         build_file = await build_request.text()
         build_find = re.findall(r'Build Number:\D+"(\d+)"', build_file)
-        return int(build_find[0]) if build_find and str.isnumeric(build_find[0]) else 9999
+        return int(build_find[0]) if build_find else default_build_number
     except asyncio.TimeoutError:
         _log.critical('Could not fetch client build number. Falling back to hardcoded value...')
-        return 9999
+        return default_build_number
 
 
 async def _get_user_agent(session: ClientSession) -> str:

--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1479,9 +1479,8 @@ async def _get_build_number(session: ClientSession) -> int:  # Thank you Discord
         build_url = 'https://discord.com/assets/' + re.compile(r'assets/+([a-z0-9]+)\.js').findall(login_page)[-2] + '.js'
         build_request = await session.get(build_url, timeout=7)
         build_file = await build_request.text()
-        build_find = 'Build Number: ").concat("'
-        build_index = build_file.find(build_find) + len(build_find)
-        return int(build_file[build_index : build_index + 6])
+        build_find = re.findall(r'Build Number:\D+"(\d+)"', build_file)
+        return int(build_find[0]) if build_find and str.isnumeric(build_find[0]) else 9999
     except asyncio.TimeoutError:
         _log.critical('Could not fetch client build number. Falling back to hardcoded value...')
         return 9999


### PR DESCRIPTION
## Summary
Fix _get_build_number find error with new string `'Build Number: ").concat("'`, issue #597 

## General Info
In latest discord website, the build number finding has been updated.

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue (please put issue # in summary).
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
