### PR TITLE
""Not for production environments"". Possible Internet traffic reduction alternative to "fixes #616"

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1477,10 +1477,10 @@ async def _get_build_number(session: ClientSession) -> int:  # Thank you Discord
     try:
         login_page_request = await session.get('https://discord.com/login', timeout=7)
         login_page = await login_page_request.text()
-        build_url = 'https://discord.com/assets/' + re.compile(r'assets/+([a-z0-9]+)\.js').findall(login_page)[-2] + '.js'
+        build_url = 'https://discord.com/assets/' + re.compile(r'assets/(sentry\.\w+)\.js').findall(login_page)[0] + '.js'
         build_request = await session.get(build_url, timeout=7)
         build_file = await build_request.text()
-        build_find = re.findall(r'Build Number:\D+"(\d+)"', build_file)
+        build_find = re.findall(r'buildNumber\D+(\d+)"', build_file)
         return int(build_find[0]) if build_find else default_build_number
     except asyncio.TimeoutError:
         _log.critical('Could not fetch client build number. Falling back to hardcoded value...')


### PR DESCRIPTION
## Summary
<!-- What is this pull request for? Does it fix any issues? -->
Fixes https://github.com/dolfies/discord.py-self/issues/616

After waiting a few months from now, if a request matching "/sentry\. [a-z0-9]+Sentry.js", we recommend merging this pull request if a matching request is running in Discord's /login.

There is no guarantee that Discord will continue to use Sentry.io forever, though,
I suggested this in the expectation that it has been used so far and will be used in the future, although the file name is different.

I hope you will keep it in a corner of your memory.

I rewrote "utils.py" to get the Build Number from a JavaScript file that contains a client that reports errors to Sentry.io.

The link to the JavaScript file is [/assets/sentry.708ca00456ca1abdfa75.js](https://discord.com/assets/sentry.708ca00456ca1abdfa75.js) The response body size is 7.82 kB.
The response body size for a GET request to /login in Discord is 11.41 kB.

Therefore, if we remove the headers from the calculation in one run of _get_build_number, we have 19.3 kB of Internet communication.


## General Info
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue (please put issue # in summary).
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
