### PR TITLE
Fix fallback build number retrieval again

### DIFF
--- a/discord/utils.py
+++ b/discord/utils.py
@@ -1477,7 +1477,7 @@ async def _get_build_number(session: ClientSession) -> int:  # Thank you Discord
     try:
         login_page_request = await session.get('https://discord.com/login', timeout=7)
         login_page = await login_page_request.text()
-        build_url = 'https://discord.com/assets/' + re.compile(r'assets/+([a-z0-9]+)\.js').findall(login_page)[-2] + '.js'
+        build_url = 'https://discord.com/assets/' + re.compile(r'assets/+([a-z.0-9]+)\.js').findall(login_page)[-2] + '.js'
         build_request = await session.get(build_url, timeout=7)
         build_file = await build_request.text()
         build_find = re.findall(r'Build Number:\D+"(\d+)"', build_file)


### PR DESCRIPTION
## Summary
<!-- What is this pull request for? Does it fix any issues? -->
Fixes breaking issue where the .js asset paths aren't being parsed

## General Info
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue (please put issue # in summary).
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
