### PR TITLE
Allow people to send metadata with activity and fix a bug

### DIFF
--- a/discord/activity.py
+++ b/discord/activity.py
@@ -227,7 +227,7 @@ class Activity(BaseActivity):
         self.flags: int = kwargs.pop('flags', 0)
         self.sync_id: Optional[str] = kwargs.pop('sync_id', None)
         self.session_id: Optional[str] = kwargs.pop('session_id', None)
-        self.buttons: Optional[List[str]] = kwargs.pop('buttons', [])
+        self.buttons: Optional[List[str]] = kwargs.pop('buttons', None)
         self.metadata: Optional[dict] = kwargs.pop('metadata', None)
 
         activity_type = kwargs.pop('type', -1)

--- a/discord/activity.py
+++ b/discord/activity.py
@@ -211,6 +211,7 @@ class Activity(BaseActivity):
         'application_id',
         'emoji',
         'buttons',
+        'metadata'
     )
 
     def __init__(self, **kwargs: Any) -> None:
@@ -226,7 +227,8 @@ class Activity(BaseActivity):
         self.flags: int = kwargs.pop('flags', 0)
         self.sync_id: Optional[str] = kwargs.pop('sync_id', None)
         self.session_id: Optional[str] = kwargs.pop('session_id', None)
-        self.buttons: List[str] = kwargs.pop('buttons', [])
+        self.buttons: Optional[List[str]] = kwargs.pop('buttons', [])
+        self.metadata: Optional[dict] = kwargs.pop('metadata', None)
 
         activity_type = kwargs.pop('type', -1)
         self.type: ActivityType = (


### PR DESCRIPTION
## Summary
It fixes the issue of people not being able to see their rpc, if they haven't set their buttons in the Activity() class. Discord doesn't seem to show the presence if a empty list of buttons is sent, so I made the default a None instead of a list.

I also gave the Activity() class access to metadata, so people could configure button urls. The implementation is basic and ignoring the Metadata() class. It could be improved.

## General Info
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue (please put issue # in summary).
- [x ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)