### PR TITLE
Use fallback "audioop" (audioop-lts) package for Python v3.13 or higher

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp>=3.7.4,<4
 tzlocal>=4.0.0,<6
 discord_protos<1.0.0
+audioop-lts; python_version>='3.13'


### PR DESCRIPTION
## Summary
Discord.py-self uses the "audioop" module which is removed in Python 3.13 and has been deprecated since 3.11.
This fix is achieved by adding the "audioop-lts" package in requirements.txt with a Python > 3.13 check.
[#9477](https://github.com/Rapptz/discord.py/issues/9477)

## General Info
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue (please put issue # in summary).
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
