### PR TITLE
Utilize provided proxies in build info fetching

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -635,7 +635,12 @@ class HTTPClient:
                 connector=self.connector, trace_configs=None if self.http_trace is None else [self.http_trace]
             )
         )
-        self.super_properties, self.encoded_super_properties = sp, _ = await utils._get_info(session)
+
+
+        proxy = self.proxy
+        proxy_auth = self.proxy_auth
+        
+        self.super_properties, self.encoded_super_properties = sp, _ = await utils._get_info(session, proxy, proxy_auth)
         _log.info('Found user agent %s, build number %s.', sp.get('browser_user_agent'), sp.get('client_build_number'))
 
         self._started = True


### PR DESCRIPTION
## Summary
<!-- What is this pull request for? Does it fix any issues? -->

## General Info
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue (please put issue # in summary).
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

Note: Documentation has not been changed as there is no documentation for the functions changed (primarily utils._get_info())

# Issue Summary:
Discord.py-self fails to connect to discord.com on services like PythonAnywhere
![image](https://github.com/user-attachments/assets/3b62bb70-086a-42e6-a5c6-b35c08c06c16)



This change adds support for the static methods that fetch information needed to build discord's super-properties. Because they did not use proxies before, services that require http requests to be routed through their proxies (PythonAnywhere) did not allow this library to run. With this fix, clients are now able to run on PythonAnywhere with zero issue. There are no breaking changes to any API provided to the end user normally, so this should be an easy merge. All handling has been done under the hood.


