### PR TITLE
Add user_installed_commands method (user_application_command_index)

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -2536,6 +2536,10 @@ class Messageable:
 
         .. versionadded:: 2.1
 
+        .. note::
+
+            Method returns only user-installed commands.
+
         Raises
         ------
         ~discord.HTTPException

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -2529,7 +2529,7 @@ class Messageable:
             most_relevant=most_relevant,
         )
 
-    async def user_installed_commands(self) -> List[Union[SlashCommand, UserCommand, MessageCommand]]:
+    async def user_application_commands(self) -> List[Union[SlashCommand, UserCommand, MessageCommand]]:
         """|coro|
 
         Returns a list of user-installed commands available.

--- a/discord/abc.py
+++ b/discord/abc.py
@@ -2529,6 +2529,38 @@ class Messageable:
             most_relevant=most_relevant,
         )
 
+    async def user_installed_commands(self) -> List[Union[SlashCommand, UserCommand, MessageCommand]]:
+        """|coro|
+
+        Returns a list of user-installed commands available.
+
+        .. versionadded:: 2.1
+
+        Raises
+        ------
+        ~discord.HTTPException
+            Getting the commands failed.
+
+        Returns
+        -------
+        List[Union[:class:`~discord.SlashCommand`, :class:`~discord.UserCommand`, :class:`~discord.MessageCommand`]]
+            A list of user-installed commands.
+        """
+        state = self._state
+        data = await state.http.user_application_command_index()
+
+        cmds = data['application_commands']
+        apps = {int(app['id']): state.create_integration_application(app) for app in data.get('applications') or []}
+
+        result = []
+
+        for cmd in cmds:
+            _, cls = _command_factory(cmd['type'])
+            application = apps.get(int(cmd['application_id']))
+            result.append(cls(state=state, data=cmd, application=application))
+
+        return result
+
     async def application_commands(self) -> List[Union[SlashCommand, UserCommand, MessageCommand]]:
         """|coro|
 

--- a/discord/client.py
+++ b/discord/client.py
@@ -100,6 +100,7 @@ from .settings import UserSettings, LegacyUserSettings, TrackingSettings, EmailS
 from .affinity import *
 from .oauth2 import OAuth2Authorization, OAuth2Token
 from .experiment import UserExperiment, GuildExperiment
+from .commands import SlashCommand, UserCommand, MessageCommand, _command_factory
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -858,6 +859,42 @@ class Client:
         await self._connection.async_setup()
 
         self._ready = asyncio.Event()
+
+    async def user_application_commands(self) -> List[Union[SlashCommand, UserCommand, MessageCommand]]:
+        """|coro|
+
+        Returns a list of user-installed commands available.
+
+        .. versionadded:: 2.1
+
+        .. note::
+
+            Method returns only user-installed commands.
+
+        Raises
+        ------
+        ~discord.HTTPException
+            Getting the commands failed.
+
+        Returns
+        -------
+        List[Union[:class:`~discord.SlashCommand`, :class:`~discord.UserCommand`, :class:`~discord.MessageCommand`]]
+            A list of user-installed commands.
+        """
+        state = self._connection
+        data = await state.http.user_application_command_index()
+
+        cmds = data['application_commands']
+        apps = {int(app['id']): state.create_integration_application(app) for app in data.get('applications') or []}
+
+        result = []
+
+        for cmd in cmds:
+            _, cls = _command_factory(cmd['type'])
+            application = apps.get(int(cmd['application_id']))
+            result.append(cls(state=state, data=cmd, application=application))
+
+        return result
 
     async def setup_hook(self) -> None:
         """|coro|

--- a/discord/commands.py
+++ b/discord/commands.py
@@ -224,6 +224,8 @@ class BaseCommand(ApplicationCommand, Hashable):
         self.application_id: int = int(data['application_id'])
         self.id: int = int(data['id'])
         self.version = int(data['version'])
+        self.integration_types = data.get('integration_types', [])
+        self.global_popularity_rank = data.get('global_popularity_rank', 0)
 
         self._default_member_permissions = _get_as_snowflake(data, 'default_member_permissions')
         dm_permission = data.get('dm_permission')  # Null means true?

--- a/discord/guild.py
+++ b/discord/guild.py
@@ -3361,6 +3361,42 @@ class Guild(Hashable):
 
         return [convert(d) for d in data]
 
+    async def user_application_commands(self) -> List[Union[SlashCommand, UserCommand, MessageCommand]]:
+        """|coro|
+
+        Returns a list of user-installed commands available.
+
+        .. versionadded:: 2.1
+
+        .. note::
+
+            Method returns only user-installed commands.
+
+        Raises
+        ------
+        ~discord.HTTPException
+            Getting the commands failed.
+
+        Returns
+        -------
+        List[Union[:class:`~discord.SlashCommand`, :class:`~discord.UserCommand`, :class:`~discord.MessageCommand`]]
+            A list of user-installed commands.
+        """
+        state = self._state
+        data = await state.http.user_application_command_index()
+
+        cmds = data['application_commands']
+        apps = {int(app['id']): state.create_integration_application(app) for app in data.get('applications') or []}
+
+        result = []
+
+        for cmd in cmds:
+            _, cls = _command_factory(cmd['type'])
+            application = apps.get(int(cmd['application_id']))
+            result.append(cls(state=state, data=cmd, application=application))
+
+        return result
+
     async def application_commands(self) -> List[Union[SlashCommand, UserCommand, MessageCommand]]:
         """|coro|
 


### PR DESCRIPTION
## Summary
I noticed that there is a user_application_command_index method in the code, but it is not used anywhere,

## General Info
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue (please put issue # in summary).
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
