### PR TITLE
Fix: WebSocketClient.close fails on Broken Pipe from curl_cffi>=0.11.1

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -861,7 +861,13 @@ class DiscordWebSocket:
             self._keep_alive = None
 
         self._close_code = code
-        await self.socket.close(code, reason)
+        try:
+            await self.socket.close(code, reason)
+        except CurlError as e:
+            if 'WS_SEND' in str(e) and 'Broken pipe' in str(e):
+                pass
+            else:
+                raise
         _log.info('Finished closing websocket')
 
 


### PR DESCRIPTION
When the server closes a WebSocket connection, calling `.close()` in curl_cffi >=0.11.1 raises a `WS_SEND` error with "Broken pipe".

This patch wraps `.close()` in a try/except block to suppress this specific non-critical error.
