### PR TITLE
Fix WebSocketClient close: tolerate WS_SEND broken pipe error

### DIFF
--- a/discord/gateway.py
+++ b/discord/gateway.py
@@ -861,7 +861,13 @@ class DiscordWebSocket:
             self._keep_alive = None
 
         self._close_code = code
-        await self.socket.close(code, reason)
+        try:
+            await self.socket.close(code, reason)
+        except CurlError as e:
+            if 'WS_SEND' in str(e) and 'Broken pipe' in str(e):
+                pass
+            else:
+                raise
         _log.info('Finished closing websocket')
 
 


### PR DESCRIPTION
## Summary
<!-- What is this pull request for? Does it fix any issues? -->

When the server closes a WebSocket connection, calling .close() in curl_cffi >=0.11.1 raises a WS_SEND error with "Broken pipe".

This patch wraps .close() in a try/except block to suppress this specific non-critical error.

```
Traceback (most recent call last):
  File "/home/ec2-user/miniconda3/envs/hunter/lib/python3.11/site-packages/discord/gateway.py", line 172, in run
    await self.ws.close(4000)
  File "/home/ec2-user/miniconda3/envs/hunter/lib/python3.11/site-packages/discord/gateway.py", line 864, in close
    await self.socket.close(code, reason)
  File "/home/ec2-user/miniconda3/envs/hunter/lib/python3.11/site-packages/curl_cffi/requests/websockets.py", line 730, in close
    await self.send(msg, CurlWsFlag.CLOSE)
  File "/home/ec2-user/miniconda3/envs/hunter/lib/python3.11/site-packages/curl_cffi/requests/websockets.py", line 675, in send
    return await self.loop.run_in_executor(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/miniconda3/envs/hunter/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/miniconda3/envs/hunter/lib/python3.11/site-packages/curl_cffi/curl.py", line 463, in ws_send
    self._check_error(ret, "WS_SEND")
  File "/home/ec2-user/miniconda3/envs/hunter/lib/python3.11/site-packages/curl_cffi/curl.py", line 154, in _check_error
    raise error
curl_cffi.curl.CurlError: Failed to WS_SEND, curl: (55) Send failure: Broken pipe. See https://curl.se/libcurl/c/libcurl-errors.html first for more details.
```


## General Info
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue (please put issue # in summary).
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
