### PR TITLE
Handle CurlError in Client.connect reconnect loop

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -50,7 +50,7 @@ from typing import (
 )
 
 import aiohttp
-from curl_cffi import CurlError # @mikasa: let Client.connect catch CurlError in reconnect handler :3
+from curl_cffi import CurlError
 
 from .user import _UserTag, RecentAvatar, User, ClientUser
 from .invite import Invite
@@ -992,7 +992,7 @@ class Client:
                 ConnectionClosed,
                 aiohttp.ClientError,
                 asyncio.TimeoutError,
-                CurlError, # @mikasa: treat CurlError like other reconnectable network errors
+                CurlError,
             ) as exc:
                 self.dispatch('disconnect')
                 if not reconnect:


### PR DESCRIPTION
## Summary
<!-- What is this pull request for? Does it fix any issues? -->
Fixes https://github.com/dolfies/discord.py-self/issues/869.

This change imports CurlError from curl_cffi and adds it to the reconnect exception tuple so these failures follow the normal reconnect/backoff path.

## General Info
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue (please put issue # in summary).
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
