### PR TITLE
Auto-proxy external URLs in activity assets

### DIFF
--- a/discord/activity.py
+++ b/discord/activity.py
@@ -245,9 +245,13 @@ class ActivityAssets:
         Discord CDN, media proxy, application, Twitch, YouTube, and Spotify assets
         are able to be used directly in activity assets by providing their URLs or URIs.
 
-        In order to provide an arbitrary image link, you must use :meth:`~discord.Client.proxy_external_application_assets`
-        or :meth:`~discord.Application.proxy_external_assets` to retrieved a proxied URL from Discord.
-        Otherwise, the image will not render in clients.
+        Arbitrary external image URLs (e.g. ``https://example.com/image.png``) can also
+        be passed directly to ``large_image`` or ``small_image``. When used with
+        :meth:`~discord.Client.change_presence`, these will be automatically proxied
+        through Discord's media CDN, as long as the activity has an ``application_id`` set.
+
+        You can also proxy them yourself with :meth:`~discord.Client.proxy_external_application_assets`
+        or :meth:`~discord.Application.proxy_external_assets` if you need more control.
 
     Parameters
     -----------
@@ -399,6 +403,15 @@ class ActivityAssets:
         if match:
             return f'spotify:{match[1]}'
         return asset
+
+    def _needs_proxy(self) -> List[str]:
+        """Returns a list of asset field names that contain unproxied external URLs."""
+        fields = []
+        for attr in ('_large_image', '_small_image'):
+            value = getattr(self, attr, None)
+            if value and value.startswith(('http://', 'https://')):
+                fields.append(attr)
+        return fields
 
     @property
     def large_image(self) -> Optional[ActivityImage]:

--- a/discord/client.py
+++ b/discord/client.py
@@ -77,7 +77,7 @@ from .enums import (
 from .mentions import AllowedMentions
 from .errors import *
 from .gateway import *
-from .activity import ActivityTypes, BaseActivity, Session, Spotify, create_activity
+from .activity import Activity, ActivityTypes, BaseActivity, Session, Spotify, create_activity
 from .voice_client import VoiceClient
 from .http import HTTPClient
 from .state import ConnectionState
@@ -1981,14 +1981,16 @@ class Client:
         if activities is MISSING:
             if activity is not MISSING:
                 activities = [activity] if activity else []
-                activities_data = [activity.to_dict()] if activity else []
             else:
                 if ws.status == 'unknown':
-                    activities_data = [activity.to_dict() for activity in self.client_activities]
+                    activities = list(self.client_activities)
                 else:
                     activities_data = self.ws.activities
-                skip_activities = True
-        else:
+                    skip_activities = True
+
+        if not skip_activities:
+            for a in activities:
+                await self._proxy_activity_assets(a)
             activities_data = [a.to_dict() for a in activities] if activities else []
 
         skip_status = status is MISSING
@@ -3664,6 +3666,20 @@ class Client:
         data = await self._connection.http.create_app_external_assets(application_id, urls)
         prefix = 'https://media.discordapp.net/'
         return [prefix + asset['external_asset_path'] for asset in data]
+
+    async def _proxy_activity_assets(self, activity: BaseActivity) -> None:
+        if not isinstance(activity, Activity) or not activity.assets or not activity.application_id:
+            return
+
+        fields = activity.assets._needs_proxy()
+        if not fields:
+            return
+
+        urls = [getattr(activity.assets, f) for f in fields]
+        proxied = await self.proxy_external_application_assets(activity.application_id, *urls)
+
+        for field, url in zip(fields, proxied):
+            setattr(activity.assets, field, activity.assets._parse_asset(url))
 
     async def teams(self, *, with_payout_account_status: bool = False) -> List[Team]:
         """|coro|

--- a/examples/rich_presence.py
+++ b/examples/rich_presence.py
@@ -1,22 +1,17 @@
 import discord
 
-# Your Developer Portal Application ID (used for proxying external assets)
+# Your Developer Portal Application ID
 APPLICATION_ID = 123456789012345678
 
-# Any direct image URLs (png/jpg/gif). Discord will proxy these.
+# Any direct image URLs (png/jpg/gif)
 LARGE_IMAGE_URL = 'image url here'
 SMALL_IMAGE_URL = 'image url here'
 
 
 class MyClient(discord.Client):
     async def on_ready(self):
-        # Proxy BOTH urls in one call (Discord supports proxying up to 2 at a time).
-        proxied_large, proxied_small = await self.proxy_external_application_assets(
-            APPLICATION_ID,
-            LARGE_IMAGE_URL,
-            SMALL_IMAGE_URL,
-        )
-
+        # External URLs are automatically proxied through Discord's CDN
+        # when passed directly to large_image/small_image.
         activity = discord.Activity(
             type=discord.ActivityType.playing,
             application_id=APPLICATION_ID,
@@ -24,9 +19,9 @@ class MyClient(discord.Client):
             details='details',
             state='state',
             assets=discord.ActivityAssets(
-                large_image=proxied_large,
+                large_image=LARGE_IMAGE_URL,
                 large_text='large_text',
-                small_image=proxied_small,
+                small_image=SMALL_IMAGE_URL,
                 small_text='small_text',
             ),
             buttons=[


### PR DESCRIPTION
Right now if you want to use an external image in your activity, you have to
manually call `proxy_external_application_assets`, get the proxied URLs back,
then pass those into `ActivityAssets`. This is pretty annoying.

This makes `change_presence` handle it for you — if your activity has an
`application_id` and the assets contain raw URLs that aren't from a known CDN
(discord, twitch, youtube, spotify), they get proxied automatically before
being sent to the gateway.

Closes #274