### PR TITLE
(typing) add silent param to disable typing indicator

### DIFF
--- a/discord/abc.py
+++ b/discord/abc.py
@@ -2125,7 +2125,7 @@ class Messageable:
         )
         return state.create_message(channel=channel, data=data)
 
-    def typing(self) -> Typing:
+    def typing(self, silent: bool = False) -> Typing:
         """Returns an asynchronous context manager that allows you to send a typing indicator to
         the destination for an indefinite period of time, or 10 seconds if the context manager
         is called using ``await``.
@@ -2157,7 +2157,7 @@ class Messageable:
         .. versionchanged:: 2.1
             Added ``message_send_cooldown`` and ``thread_create_cooldown`` attributes to the context manager.
         """
-        return Typing(self)
+        return Typing(self, silent=silent)
 
     async def fetch_message(self, id: int, /) -> Message:
         """|coro|

--- a/discord/context_managers.py
+++ b/discord/context_managers.py
@@ -52,12 +52,13 @@ def _typing_done_callback(fut: asyncio.Future) -> None:
 
 
 class Typing:
-    def __init__(self, messageable: Messageable) -> None:
+    def __init__(self, messageable: Messageable, silent: bool) -> None:
         self.loop: asyncio.AbstractEventLoop = messageable._state.loop
         self.messageable: Messageable = messageable
         self.channel: Optional[MessageableChannel] = None
         self.message_send_cooldown: int = 0
         self.thread_create_cooldown: int = 0
+        self.silent = silent
 
     def _update(self, data: TypingResponse) -> None:
         self.message_send_cooldown = data.get('message_send_cooldown_ms', 0)
@@ -91,6 +92,8 @@ class Typing:
                 self._update(data)
 
     async def __aenter__(self) -> None:
+        if self.silent:
+            return
         channel = await self._get_channel()
         await channel._state.http.send_typing(channel.id)
         self.task: asyncio.Task[None] = self.loop.create_task(self.do_typing())
@@ -102,4 +105,6 @@ class Typing:
         exc: Optional[BE],
         traceback: Optional[TracebackType],
     ) -> None:
+        if self.silent:
+            return
         self.task.cancel()


### PR DESCRIPTION
## Summary
<!-- What is this pull request for? Does it fix any issues? -->
Add `silent: bool` parameter to `channel.typing(silent=True)` to allow sending messages without triggering the typing indicator.

This is useful for selfbots that want to avoid showing typing while still using the same syntax
## General Info
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue (please put issue # in summary).
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
