### PR TITLE
Fixes error reported by idk on telegram

### DIFF
--- a/discord/state.py
+++ b/discord/state.py
@@ -3548,7 +3548,7 @@ class ConnectionState:
         self.dispatch('call_update', old_call, call)
 
     def parse_call_delete(self, data: gw.CallDeleteEvent) -> None:
-        call = self._calls.pop(int(data['channel_id']), None)
+        call = self._calls.get(int(data['channel_id']), None)
         if call is not None:
             if data.get('unavailable'):
                 old_call = copy.copy(call)


### PR DESCRIPTION
Message from telegram by idk
I saw this 
[2026-07-01 12:26:35] [WARNING ] discord.state: INTERACTION_SUCCESS referencing an unknown interaction ID: 1521733736650117130. Discarding. on line 3560, discord/state.py, its not self._interactions.pop, its self._interactions.get

Message:
https://t.me/dpy_self_discussions/41969

## Summary
<!-- What is this pull request for? Does it fix any issues? -->
It fixes a error that poping a call during delete when it was supposed to be get

```py
[2026-07-01 12:26:35] [WARNING ] discord.state: INTERACTION_SUCCESS referencing an unknown interaction ID: 1521733736650117130. Discarding.
on line 3560, discord/[state.py](https://state.py/), its not self._interactions.pop, its self._interactions.get
```

Changes tested only for logical since its a logical issue

## General Info
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue (please put issue # in summary).
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
