### PR TITLE
Add display name style, collectibles, pronouns, and profile editing support to Member and ClientUser

### DIFF
--- a/discord/http.py
+++ b/discord/http.py
@@ -1265,8 +1265,11 @@ class HTTPClient:
         params = {'with_analytics_token': str(with_analytics_token).lower()}
         return self.request(Route('GET', '/users/@me'), params=params)
 
-    def edit_profile(self, payload: Dict[str, Any]) -> Response[user.UserWithToken]:
+    def edit_current_user(self, payload: Dict[str, Any]) -> Response[user.UserWithToken]:
         return self.request(Route('PATCH', '/users/@me'), json=payload)
+
+    def edit_current_user_profile(self, payload: Dict[str, Any]) -> Response[profile.ProfileMetadata]:
+        return self.request(Route('PATCH', '/users/@me/profile'), json=payload)
 
     def pomelo(self, username: str) -> Response[user.User]:
         payload = {'username': username}

--- a/discord/member.py
+++ b/discord/member.py
@@ -852,13 +852,7 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
         """
         return self.guild_display_name_style or self.global_display_name_style
 
-    def global_collectibles(self) -> List[Collectible]:
-        """List[:class:`Collectible`]: Returns the user's global collectibles.
-
-        .. versionadded:: 2.2
-        """
-        return self._user.collectibles()
-
+    @property
     def guild_collectibles(self) -> List[Collectible]:
         """List[:class:`Collectible`]: Returns the member's guild collectibles.
 
@@ -868,14 +862,16 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
             return []
         return [Collectible(state=self._state, type=key, data=value) for key, value in self._collectibles.items() if value]  # type: ignore
 
+    @property
     def collectibles(self) -> List[Collectible]:
-        """List[:class:`Collectible`]: Returns the member's collectibles.
+        """List[:class:`Collectible`]: Returns the member's or user's collectibles.
 
-        This will return the guild collectibles if available, otherwise it will return the global collectibles.
+        This will return the guild specific collectibles if available, otherwise it will
+        return the user's collectibles.
 
         .. versionadded:: 2.2
         """
-        return self.guild_collectibles() or self.global_collectibles()
+        return self.guild_collectibles or self._user.collectibles()
 
     async def ban(
         self,
@@ -924,10 +920,9 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
         bypass_verification: bool = MISSING,
         display_name_font: Optional[NameFont] = MISSING,
         display_name_effect: Optional[NameEffect] = MISSING,
+        display_name_colours: Optional[List[Colour]] = MISSING,
         display_name_colors: Optional[List[Colour]] = MISSING,
-        avatar_decoration_id: Optional[int] = MISSING,
         avatar_decoration_sku_id: Optional[int] = MISSING,
-        nameplate_id: Optional[int] = MISSING,
         nameplate_sku_id: Optional[int] = MISSING,
         pronouns: Optional[str] = MISSING,
         avatar: Optional[Union[bytes, RecentAvatar]] = MISSING,
@@ -1027,24 +1022,14 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
             You can only change your own display name effect.
 
             .. versionadded:: 2.2
-        display_name_colors: Optional[List[:class:`Colour`]]
-            The member's new display name colors. Pass ``None`` to remove the colors.
-            You can only change your own display name colors.
-
-            .. versionadded:: 2.2
-        avatar_decoration_id: Optional[:class:`int`]
-            The member's new avatar decoration ID. Pass ``None`` to remove the decoration.
-            You can only change your own avatar decoration.
+        display_name_colours: Optional[List[:class:`Colour`]]
+            The member's new display name colours. Pass ``None`` to remove the colours.
+            You can only change your own display name colours.
 
             .. versionadded:: 2.2
         avatar_decoration_sku_id: Optional[:class:`int`]
             The member's new avatar decoration SKU ID. Pass ``None`` to remove the decoration.
             You can only change your own avatar decoration.
-
-            .. versionadded:: 2.2
-        nameplate_id: Optional[:class:`int`]
-            The member's new nameplate ID. Pass ``None`` to remove the nameplate.
-            You can only change your own nameplate.
 
             .. versionadded:: 2.2
         nameplate_sku_id: Optional[:class:`int`]
@@ -1131,26 +1116,21 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
             else:
                 me_payload['display_name_effect_id'] = display_name_effect.value
 
-        if display_name_colors is not MISSING:
-            if display_name_colors is None:
+        if display_name_colours is not MISSING or display_name_colors is not MISSING:
+            colors = display_name_colours if display_name_colours is not MISSING else display_name_colors
+            if colors is None:
                 me_payload['display_name_colors'] = None
-            elif not isinstance(display_name_colors, list) or not all(
-                isinstance(color, Colour) for color in display_name_colors
-            ):
-                raise TypeError('display_name_colors must be a list of Colour')
+            elif not isinstance(colors, list) or not all(isinstance(colour, Colour) for colour in colors):
+                raise TypeError('display_name_colo(u)rs must be a list of Colour')
             else:
-                me_payload['display_name_colors'] = [color.value for color in display_name_colors]
+                me_payload['display_name_colors'] = [color.value for color in colors]
 
-        if avatar_decoration_id is not MISSING:
-            me_payload['avatar_decoration_id'] = avatar_decoration_id
         if avatar_decoration_sku_id is not MISSING:
             me_payload['avatar_decoration_sku_id'] = avatar_decoration_sku_id
 
         collectibles_payload: Dict[str, Any] = {}
 
         nameplate_payload: Dict[str, Any] = {}
-        if nameplate_id is not MISSING:
-            nameplate_payload['id'] = nameplate_id
         if nameplate_sku_id is not MISSING:
             nameplate_payload['sku_id'] = nameplate_sku_id
         if nameplate_payload:

--- a/discord/member.py
+++ b/discord/member.py
@@ -35,14 +35,15 @@ import discord.abc
 from . import utils
 from .asset import Asset
 from .utils import MISSING
-from .user import BaseUser, User, _UserTag
+from .user import BaseUser, User, _UserTag, DisplayNameStyle, RecentAvatar
 from .permissions import Permissions
-from .enums import Status, try_enum
+from .enums import Status, NameFont, NameEffect, try_enum
 from .errors import ClientException
 from .colour import Colour
 from .object import Object
 from .flags import MemberFlags
 from .voice_client import VoiceClient
+from .collectible import Collectible
 
 __all__ = (
     'VoiceState',
@@ -70,7 +71,12 @@ if TYPE_CHECKING:
         UserWithMember as UserWithMemberPayload,
     )
     from .types.gateway import GuildMemberUpdateEvent
-    from .types.user import AvatarDecorationData, PartialUser as PartialUserPayload
+    from .types.user import (
+        AvatarDecorationData,
+        PartialUser as PartialUserPayload,
+        DisplayNameStyle as DisplayNameStylePayload,
+        UserCollectibles as UserCollectiblesPayload,
+    )
     from .abc import Snowflake
     from .state import ConnectionState, Presence
     from .message import Message
@@ -79,7 +85,6 @@ if TYPE_CHECKING:
     from .relationship import Relationship
     from .calls import PrivateCall
     from .primary_guild import PrimaryGuild
-    from .collectible import Collectible
 
     VocalGuildChannel = Union[VoiceChannel, StageChannel]
     ConnectableChannel = Union[VocalGuildChannel, DMChannel, GroupChannel]
@@ -281,6 +286,8 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
         '_avatar_decoration_data',
         '_banner',
         '_flags',
+        '_display_name_style',
+        '_collectibles',
     )
 
     if TYPE_CHECKING:
@@ -316,7 +323,6 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
         accent_color: Optional[Colour]
         accent_colour: Optional[Colour]
         primary_guild: PrimaryGuild
-        collectibles: List[Collectible]
 
     def __init__(self, *, data: MemberWithUserPayload, guild: Guild, state: ConnectionState):
         self._state: ConnectionState = state
@@ -333,6 +339,8 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
         self._banner: Optional[str] = data.get('banner')
         self._flags: int = data.get('flags', 0)
         self.timed_out_until: Optional[datetime.datetime] = utils.parse_time(data.get('communication_disabled_until'))
+        self._display_name_style: Optional[DisplayNameStylePayload] = data.get('display_name_styles', None)
+        self._collectibles: Optional[UserCollectiblesPayload] = data.get('collectibles', None)
 
     def __str__(self) -> str:
         return str(self._user)
@@ -369,6 +377,8 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
         self._banner = data.get('banner')
         self._flags = data.get('flags', 0)
         self.timed_out_until = utils.parse_time(data.get('communication_disabled_until'))
+        self._display_name_style = data.get('display_name_styles', None)
+        self._collectibles = data.get('collectibles', None)
 
     @classmethod
     def _try_upgrade(cls, *, data: UserWithMemberPayload, guild: Guild, state: ConnectionState) -> Union[User, Self]:
@@ -398,6 +408,8 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
         self._avatar = member._avatar
         self._avatar_decoration_data = member._avatar_decoration_data
         self._banner = member._banner
+        self._display_name_style = member._display_name_style
+        self._collectibles = member._collectibles
 
         # Reference will not be copied unless necessary by PRESENCE_UPDATE
         # See below
@@ -425,6 +437,8 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
         self._avatar = data.get('avatar')
         self._banner = data.get('banner')
         self._flags = data.get('flags', 0)
+        self._display_name_style = data.get('display_name_styles', None)
+        self._collectibles = data.get('collectibles', None)
 
         attrs = {'joined_at', 'premium_since', '_roles', '_avatar', '_banner', 'timed_out_until', 'nick', 'pending'}
 
@@ -809,6 +823,63 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
         """
         return MemberFlags._from_value(self._flags)
 
+    @property
+    def guild_display_name_style(self) -> Optional[DisplayNameStyle]:
+        """Optional[:class:`DisplayNameStylePayload`]: Returns the member's display name style in the guild.
+
+        .. versionadded:: 2.2
+        """
+        if self._display_name_style is None:
+            return None
+
+        return DisplayNameStyle(data=self._display_name_style)
+
+    @property
+    def global_display_name_style(self) -> Optional[DisplayNameStyle]:
+        """Optional[:class:`DisplayNameStylePayload`]: Returns the user's global display name style.
+
+        .. versionadded:: 2.2
+        """
+        if self._user._display_name_style is None:
+            return None
+
+        return DisplayNameStyle(data=self._user._display_name_style)
+
+    @property
+    def display_name_style(self) -> Optional[DisplayNameStyle]:
+        """Optional[:class:`DisplayNameStylePayload`]: Returns the member's display name style.
+
+        This will return the guild display name style if available, otherwise it will return the global display name style.
+
+        .. versionadded:: 2.2
+        """
+        return self.guild_display_name_style or self.global_display_name_style
+
+    def global_collectibles(self) -> List[Collectible]:
+        """Optional[List[:class:`Collectible`]]: Returns the user's global collectibles.
+
+        .. versionadded:: 2.2
+        """
+        return self._user.collectibles()
+
+    def guild_collectibles(self) -> List[Collectible]:
+        """Optional[List[:class:`Collectible`]]: Returns the member's guild collectibles.
+
+        .. versionadded:: 2.2
+        """
+        if self._collectibles is None:
+            return []
+        return [Collectible(state=self._state, type=key, data=value) for key, value in self._collectibles.items() if value]  # type: ignore
+
+    def collectibles(self) -> Optional[List[Collectible]]:
+        """Optional[List[:class:`Collectible`]]: Returns the member's collectibles.
+
+        This will return the guild collectibles if available, otherwise it will return the global collectibles.
+
+        .. versionadded:: 2.2
+        """
+        return self.guild_collectibles() or self.global_collectibles()
+
     async def ban(
         self,
         *,
@@ -851,10 +922,19 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
         roles: Collection[discord.abc.Snowflake] = MISSING,
         voice_channel: Optional[VocalGuildChannel] = MISSING,
         timed_out_until: Optional[datetime.datetime] = MISSING,
-        avatar: Optional[bytes] = MISSING,
         banner: Optional[bytes] = MISSING,
         bio: Optional[str] = MISSING,
         bypass_verification: bool = MISSING,
+        display_name_font: Optional[NameFont] = MISSING,
+        display_name_effect: Optional[NameEffect] = MISSING,
+        display_name_colors: Optional[List[Colour]] = MISSING,
+        avatar_decoration_id: Optional[int] = MISSING,
+        avatar_decoration_sku_id: Optional[int] = MISSING,
+        nameplate_id: Optional[int] = MISSING,
+        nameplate_sku_id: Optional[int] = MISSING,
+        pronouns: Optional[str] = MISSING,
+        avatar: Optional[Union[bytes, RecentAvatar]] = MISSING,
+        avatar_description: str = MISSING,
         reason: Optional[str] = None,
     ) -> Optional[Member]:
         """|coro|
@@ -918,11 +998,14 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
             This must be a timezone-aware datetime object. Consider using :func:`utils.utcnow`.
 
             .. versionadded:: 2.0
-        avatar: Optional[:class:`bytes`]
+        avatar: Optional[Union[:class:`bytes`, :class:`RecentAvatar`]]
             The member's new guild avatar. Pass ``None`` to remove the avatar.
             You can only change your own guild avatar.
 
             .. versionadded:: 2.0
+            .. versionchanged:: 2.2
+
+                You can now pass a :class:`RecentAvatar` to set a recent user avatar as the guild avatar.
         banner: Optional[:class:`bytes`]
             The member's new guild banner. Pass ``None`` to remove the banner.
             You can only change your own guild banner.
@@ -937,6 +1020,54 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
             Indicates if the member should be allowed to bypass the guild verification requirements.
 
             .. versionadded:: 2.0
+        display_name_font: Optional[:class:`NameFont`]
+            The member's new display name font. Pass ``None`` to remove the font.
+            You can only change your own display name font.
+
+            .. versionadded:: 2.2
+        display_name_effect: Optional[:class:`NameEffect`]
+            The member's new display name effect. Pass ``None`` to remove the effect.
+            You can only change your own display name effect.
+
+            .. versionadded:: 2.2
+        display_name_colors: Optional[List[:class:`NameColor`]]
+            The member's new display name colors. Pass ``None`` to remove the colors.
+            You can only change your own display name effect.
+
+            .. versionadded:: 2.2
+        avatar_decoration_id: Optional[:class:`int`]
+            The member's new avatar decoration ID. Pass ``None`` to remove the decoration.
+            You can only change your own avatar decoration.
+
+            .. versionadded:: 2.2
+        avatar_decoration_sku_id: Optional[:class:`int`]
+            The member's new avatar decoration SKU ID. Pass ``None`` to remove the decoration.
+            You can only change your own avatar decoration.
+
+            .. versionadded:: 2.2
+        nameplate_id: Optional[:class:`int`]
+            The member's new nameplate ID. Pass ``None`` to remove the nameplate.
+            You can only change your own nameplate.
+
+            .. versionadded:: 2.2
+        nameplate_sku_id: Optional[:class:`int`]
+            The member's new nameplate SKU ID. Pass ``None`` to remove the nameplate.
+            You can only change your own nameplate.
+
+            .. versionadded:: 2.2
+        pronouns: Optional[:class:`str`]
+            The member's new pronouns. Pass ``None`` to remove the pronouns.
+            You can only change your own pronouns.
+
+            .. versionadded:: 2.2
+
+        avatar_description: Optional[:class:`str`]
+            The description of the user's newly-uploaded avatar, used for displaying in recent avatars.
+            Formatted typically as "{filename}, added {date}".
+            Not applicable when setting a :class:`RecentAvatar`.
+
+            ... versionadded:: 2.2
+
         reason: Optional[:class:`str`]
             The reason for editing this member. Shows up on the audit log.
 
@@ -948,6 +1079,10 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
             The operation failed.
         TypeError
             The datetime object passed to ``timed_out_until`` was not timezone-aware.
+            `display_name_font` parameter was not a :class:`NameFont`.
+            `display_name_effect` parameter was not a :class:`NameEffect`.
+            `display_name_colors` parameter was not a list of :class:`Colour`.
+
 
         Returns
         --------
@@ -959,23 +1094,80 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
         guild_id = self.guild.id
         me = self._user.id == self._state.self_id
         payload: Dict[str, Any] = {}
+        me_payload: Dict[str, Any] = {}
         data = None
 
         if nick is not MISSING:
             payload['nick'] = nick
+            me_payload['nick'] = nick
 
         if avatar is not MISSING:
-            payload['avatar'] = utils._bytes_to_base64_data(avatar) if avatar is not None else None
+            if isinstance(avatar, RecentAvatar):
+                me_payload['avatar_id'] = avatar.id
+            elif avatar is not None:
+                me_payload['avatar'] = utils._bytes_to_base64_data(avatar)
+            else:
+                me_payload['avatar'] = None
+
+        if avatar_description is not MISSING:
+            me_payload['avatar_description'] = avatar_description
 
         if banner is not MISSING:
-            payload['banner'] = utils._bytes_to_base64_data(banner) if banner is not None else None
+            me_payload['banner'] = utils._bytes_to_base64_data(banner) if banner is not None else None
 
         if bio is not MISSING:
-            payload['bio'] = bio or ''
+            me_payload['bio'] = bio or ''
 
-        if me and payload:
-            data = await http.edit_me(self.guild.id, **payload)
-            payload = {}
+        if display_name_font is not MISSING:
+            if display_name_font is None:
+                me_payload['display_name_font_id'] = None
+            elif not isinstance(display_name_font, NameFont):
+                raise TypeError('display_name_font must be a NameFont')
+            else:
+                me_payload['display_name_font_id'] = display_name_font.value
+
+        if display_name_effect is not MISSING:
+            if display_name_effect is None:
+                me_payload['display_name_effect_id'] = None
+            elif not isinstance(display_name_effect, NameEffect):
+                raise TypeError('display_name_effect must be a NameEffect')
+            else:
+                me_payload['display_name_effect_id'] = display_name_effect.value
+
+        if display_name_colors is not MISSING:
+            if display_name_colors is None:
+                me_payload['display_name_colors'] = None
+            elif not isinstance(display_name_colors, list) or not all(
+                isinstance(color, Colour) for color in display_name_colors
+            ):
+                raise TypeError('display_name_colors must be a list of Colour')
+            else:
+                me_payload['display_name_colors'] = [color.value for color in display_name_colors]
+
+        if avatar_decoration_id is not MISSING:
+            me_payload['avatar_decoration_id'] = avatar_decoration_id
+        if avatar_decoration_sku_id is not MISSING:
+            me_payload['avatar_decoration_sku_id'] = avatar_decoration_sku_id
+
+        collectibles_payload: Dict[str, Any] = {}
+        nameplate_payload: Dict[str, Any] = {}
+        if nameplate_id is not MISSING:
+            nameplate_payload['id'] = nameplate_id
+        if nameplate_sku_id is not MISSING:
+            nameplate_payload['sku_id'] = nameplate_sku_id
+
+        if nameplate_payload:
+            me_payload['nameplate'] = nameplate_payload
+
+        if collectibles_payload:
+            me_payload['collectibles'] = collectibles_payload
+
+        if pronouns is not MISSING:
+            me_payload['pronouns'] = pronouns
+
+        if me and me_payload:
+            data = await http.edit_me(self.guild.id, **me_payload)
+            me_payload = {}
 
         if deafen is not MISSING:
             payload['deaf'] = deafen

--- a/discord/member.py
+++ b/discord/member.py
@@ -825,7 +825,7 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
 
     @property
     def guild_display_name_style(self) -> Optional[DisplayNameStyle]:
-        """Optional[:class:`DisplayNameStylePayload`]: Returns the member's display name style in the guild.
+        """Optional[:class:`DisplayNameStyle`]: Returns the member's display name style in the guild.
 
         .. versionadded:: 2.2
         """
@@ -836,7 +836,7 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
 
     @property
     def global_display_name_style(self) -> Optional[DisplayNameStyle]:
-        """Optional[:class:`DisplayNameStylePayload`]: Returns the user's global display name style.
+        """Optional[:class:`DisplayNameStyle`]: Returns the user's global display name style.
 
         .. versionadded:: 2.2
         """
@@ -847,7 +847,7 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
 
     @property
     def display_name_style(self) -> Optional[DisplayNameStyle]:
-        """Optional[:class:`DisplayNameStylePayload`]: Returns the member's display name style.
+        """Optional[:class:`DisplayNameStyle`]: Returns the member's display name style.
 
         This will return the guild display name style if available, otherwise it will return the global display name style.
 
@@ -856,14 +856,14 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
         return self.guild_display_name_style or self.global_display_name_style
 
     def global_collectibles(self) -> List[Collectible]:
-        """Optional[List[:class:`Collectible`]]: Returns the user's global collectibles.
+        """List[:class:`Collectible`]: Returns the user's global collectibles.
 
         .. versionadded:: 2.2
         """
         return self._user.collectibles()
 
     def guild_collectibles(self) -> List[Collectible]:
-        """Optional[List[:class:`Collectible`]]: Returns the member's guild collectibles.
+        """List[:class:`Collectible`]: Returns the member's guild collectibles.
 
         .. versionadded:: 2.2
         """
@@ -871,8 +871,8 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
             return []
         return [Collectible(state=self._state, type=key, data=value) for key, value in self._collectibles.items() if value]  # type: ignore
 
-    def collectibles(self) -> Optional[List[Collectible]]:
-        """Optional[List[:class:`Collectible`]]: Returns the member's collectibles.
+    def collectibles(self) -> List[Collectible]:
+        """List[:class:`Collectible`]: Returns the member's collectibles.
 
         This will return the guild collectibles if available, otherwise it will return the global collectibles.
 
@@ -1030,9 +1030,9 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
             You can only change your own display name effect.
 
             .. versionadded:: 2.2
-        display_name_colors: Optional[List[:class:`NameColor`]]
+        display_name_colors: Optional[List[:class:`Colour`]]
             The member's new display name colors. Pass ``None`` to remove the colors.
-            You can only change your own display name effect.
+            You can only change your own display name colors.
 
             .. versionadded:: 2.2
         avatar_decoration_id: Optional[:class:`int`]
@@ -1150,12 +1150,12 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
             me_payload['avatar_decoration_sku_id'] = avatar_decoration_sku_id
 
         collectibles_payload: Dict[str, Any] = {}
+
         nameplate_payload: Dict[str, Any] = {}
         if nameplate_id is not MISSING:
             nameplate_payload['id'] = nameplate_id
         if nameplate_sku_id is not MISSING:
             nameplate_payload['sku_id'] = nameplate_sku_id
-
         if nameplate_payload:
             me_payload['nameplate'] = nameplate_payload
 

--- a/discord/member.py
+++ b/discord/member.py
@@ -840,10 +840,7 @@ class Member(discord.abc.Messageable, discord.abc.Connectable, _UserTag):
 
         .. versionadded:: 2.2
         """
-        if self._user._display_name_style is None:
-            return None
-
-        return DisplayNameStyle(data=self._user._display_name_style)
+        return self._user.display_name_style
 
     @property
     def display_name_style(self) -> Optional[DisplayNameStyle]:

--- a/discord/types/member.py
+++ b/discord/types/member.py
@@ -26,7 +26,7 @@ from typing import Optional, TypedDict
 
 from .activity import BasePresenceUpdate
 from .snowflake import SnowflakeList
-from .user import AvatarDecorationData, PartialUser
+from .user import AvatarDecorationData, PartialUser, DisplayNameStyle, UserCollectibles
 
 
 class Nickname(TypedDict):
@@ -50,6 +50,8 @@ class Member(PartialMember, total=False):
     pending: bool
     communication_disabled_until: str
     avatar_decoration_data: AvatarDecorationData
+    display_name_style: DisplayNameStyle
+    collectibles: UserCollectibles
 
 
 class _OptionalMemberWithUser(PartialMember, total=False):

--- a/discord/user.py
+++ b/discord/user.py
@@ -876,7 +876,7 @@ class ClientUser(BaseUser):
             .. deprecated:: 2.2
 
                 This parameter is deprecated and will be removed in a future version.
-                Use :attr:`avatar_decoration_id` and :attr:`avatar_decoration_sku_id` instead.
+                Use ``avatar_decoration_id`` and ``avatar_decoration_sku_id`` instead.
         banner: :class:`bytes`
             A :term:`py:bytes-like object` representing the image to upload.
             Could be ``None`` to denote no banner.

--- a/discord/user.py
+++ b/discord/user.py
@@ -65,7 +65,7 @@ if TYPE_CHECKING:
     from .client import Client
     from .member import VoiceState
     from .message import Message
-    from .profile import UserProfile
+    from .profile import ProfileMetadata, UserProfile
     from .state import ConnectionState
     from .types.channel import DMChannel as DMChannelPayload
     from .types.user import (
@@ -818,10 +818,9 @@ class ClientUser(BaseUser):
         primary_guild: Optional[discord.abc.Snowflake] = MISSING,
         display_name_font: Optional[NameFont] = MISSING,
         display_name_effect: Optional[NameEffect] = MISSING,
+        display_name_colours: Optional[List[Colour]] = MISSING,
         display_name_colors: Optional[List[Colour]] = MISSING,
-        nameplate_id: Optional[int] = MISSING,
         nameplate_sku_id: Optional[int] = MISSING,
-        avatar_decoration_id: Optional[int] = MISSING,
         avatar_decoration_sku_id: Optional[int] = MISSING,
         pronouns: Optional[str] = MISSING,
     ) -> ClientUser:
@@ -842,6 +841,9 @@ class ClientUser(BaseUser):
         .. versionchanged:: 2.0
             This function will now raise :exc:`ValueError` instead of
             ``InvalidArgument``.
+
+        .. versionchanged:: 2.2
+            The ``avatar_decoration`` parameter was removed in favor of ``avatar_decoration_sku_id``.
 
         Parameters
         -----------
@@ -925,20 +927,12 @@ class ClientUser(BaseUser):
             The effect to use for your display name. Pass ``None`` to remove the effect.
 
             .. versionadded:: 2.2
-        display_name_colors: Optional[List[:class:`Colour`]]
+        display_name_colours: Optional[List[:class:`Colour`]]
             The colours to use for your display name. Pass ``None`` to remove the colours.
-
-            .. versionadded:: 2.2
-        nameplate_id: Optional[:class:`int`]
-            The ID of the nameplate to use. Pass ``None`` to remove the nameplate.
 
             .. versionadded:: 2.2
         nameplate_sku_id: Optional[:class:`int`]
             The SKU ID of the nameplate to use. Pass ``None`` to remove the nameplate.
-
-            .. versionadded:: 2.2
-        avatar_decoration_id: Optional[:class:`int`]
-            The ID of the avatar decoration to use. Pass ``None`` to remove the avatar decoration.
 
             .. versionadded:: 2.2
         avatar_decoration_sku_id: Optional[:class:`int`]
@@ -1086,21 +1080,19 @@ class ClientUser(BaseUser):
             else:
                 args['display_name_effect_id'] = display_name_effect.value
 
-        if display_name_colors is not MISSING:
-            if display_name_colors is None:
-                args['display_name_colors'] = None
-            elif not isinstance(display_name_colors, list) or not all(isinstance(c, Colour) for c in display_name_colors):
-                raise ValueError('`display_name_colors` parameter was not a list of Colour')
-            else:
-                args['display_name_colors'] = [c.value for c in display_name_colors]
+        if display_name_colors is not MISSING or display_name_colours is not MISSING:
+            display_name_colours = display_name_colours if display_name_colours is not MISSING else display_name_colors
 
-        if nameplate_id is not MISSING:
-            args['nameplate_id'] = nameplate_id
+            if display_name_colours is None:
+                args['display_name_colours'] = None
+            elif not isinstance(display_name_colours, list) or not all(isinstance(c, Colour) for c in display_name_colours):
+                raise ValueError('`display_name_colours` parameter was not a list of Colour')
+            else:
+                args['display_name_colours'] = [c.value for c in display_name_colours]
+
         if nameplate_sku_id is not MISSING:
             args['nameplate_sku_id'] = nameplate_sku_id
 
-        if avatar_decoration_id is not MISSING:
-            args['avatar_decoration_id'] = avatar_decoration_id
         if avatar_decoration_sku_id is not MISSING:
             args['avatar_decoration_sku_id'] = avatar_decoration_sku_id
 
@@ -1108,13 +1100,98 @@ class ClientUser(BaseUser):
             args['pronouns'] = pronouns
 
         if args or data is None:
-            data = await http.edit_profile(args)
+            data = await http.edit_current_user(args)
             try:
                 http._token(data['token'])
             except KeyError:
                 pass
 
         return self.__class__(state=self._state, data=data)  # type: ignore # ???
+
+    async def edit_profile(
+        self,
+        *,
+        pronouns: Optional[str] = MISSING,
+        bio: Optional[str] = MISSING,
+        banner: Optional[bytes] = MISSING,
+        accent_colour: Optional[Colour] = MISSING,
+        accent_color: Optional[Colour] = MISSING,
+        theme_colours: Optional[List[Colour]] = MISSING,
+        theme_colors: Optional[List[Colour]] = MISSING,
+        popout_animation_particle_type: Optional[int] = MISSING,
+        emoji_id: Optional[int] = MISSING,
+        profile_effect_id: Optional[int] = MISSING,
+    ) -> ProfileMetadata:
+        """|coro|
+
+        Edits the current user's profile metadata.
+
+        .. versionadded:: 2.2
+
+        Parameters
+        -----------
+        pronouns: Optional[:class:`str`]
+            The pronouns to use for your profile. Can be up to 40 characters.
+            Pass ``None`` to remove the pronouns.
+        bio: Optional[:class:`str`]
+            Your "about me" section. Can be up to 190 characters.
+            Could be ``None`` to represent no bio.
+        banner: Optional[:class:`bytes`]
+            A :term:`py:bytes-like object` representing the new banner.
+            Could be ``None`` to denote no banner.
+        accent_colour: Optional[:class:`Colour`]
+            A :class:`Colour` object of the colour you want to set your profile to.
+            Pass ``None`` to remove the accent colour.
+        theme_colours: Optional[List[:class:`Colour`]]
+            A list of two :class:`Colour` objects to use for your profile theme.
+            Pass ``None`` to remove the theme colours.
+        popout_animation_particle_type: Optional[:class:`int`]
+            The ID of the particle type to use for your profile popout animation.
+            Pass ``None`` to remove the particle type.
+        emoji_id: Optional[:class:`int`]
+            The ID of the emoji to use for your profile. Pass ``None`` to remove the emoji.
+        profile_effect_id: Optional[:class:`int`]
+            The ID of the profile effect to use for your profile. Pass ``None`` to remove the profile effect.
+
+        Raises
+        ------
+        HTTPException
+            Editing your profile failed.
+
+        Returns
+        ---------
+        :class:`ProfileMetadata`
+            The newly edited profile metadata.
+        """
+        state = self._state
+        payload: Dict[str, Any] = {}
+        data = None
+
+        if pronouns is not MISSING:
+            payload['pronouns'] = pronouns
+        if bio is not MISSING:
+            payload['bio'] = bio or ''
+        if banner is not MISSING:
+            payload['banner'] = _bytes_to_base64_data(banner) if banner is not None else None
+        if accent_color is not MISSING or accent_colour is not MISSING:
+            colour = accent_colour if accent_colour is not MISSING else accent_color
+            payload['accent_color'] = colour.value if colour is not None else None
+        if theme_colors is not MISSING or theme_colours is not MISSING:
+            theme_colours = theme_colours if theme_colours is not MISSING else theme_colors
+            payload['theme_colors'] = [c.value for c in theme_colours] if theme_colours is not None else None
+        if popout_animation_particle_type is not MISSING:
+            payload['popout_animation_particle_type'] = popout_animation_particle_type
+        if emoji_id is not MISSING:
+            payload['emoji_id'] = emoji_id
+        if profile_effect_id is not MISSING:
+            payload['profile_effect_id'] = profile_effect_id
+
+        if payload or data is None:
+            data = await state.http.edit_current_user_profile(payload)
+
+        from .profile import ProfileMetadata
+
+        return ProfileMetadata(id=self.id, state=self._state, data=data)
 
 
 class User(BaseUser, discord.abc.Connectable, discord.abc.Messageable):

--- a/discord/user.py
+++ b/discord/user.py
@@ -816,6 +816,14 @@ class ClientUser(BaseUser):
         date_of_birth: datetime.date = MISSING,
         pomelo: bool = MISSING,
         primary_guild: Optional[discord.abc.Snowflake] = MISSING,
+        display_name_font: Optional[NameFont] = MISSING,
+        display_name_effect: Optional[NameEffect] = MISSING,
+        display_name_colors: Optional[List[Colour]] = MISSING,
+        nameplate_id: Optional[int] = MISSING,
+        nameplate_sku_id: Optional[int] = MISSING,
+        avatar_decoration_id: Optional[int] = MISSING,
+        avatar_decoration_sku_id: Optional[int] = MISSING,
+        pronouns: Optional[str] = MISSING,
     ) -> ClientUser:
         """|coro|
 
@@ -865,6 +873,10 @@ class ClientUser(BaseUser):
             Could be ``None`` to denote no avatar decoration.
 
             .. versionadded:: 2.0
+            .. deprecated:: 2.2
+
+                This parameter is deprecated and will be removed in a future version.
+                Use :attr:`avatar_decoration_id` and :attr:`avatar_decoration_sku_id` instead.
         banner: :class:`bytes`
             A :term:`py:bytes-like object` representing the image to upload.
             Could be ``None`` to denote no banner.
@@ -905,6 +917,38 @@ class ClientUser(BaseUser):
             - If ``None`` is passed, then the primary guild is removed and the identity is disabled.
 
             .. versionadded:: 2.2
+        display_name_font: Optional[:class:`NameFont`]
+            The font to use for your display name. Pass ``None`` to remove the font.
+
+            .. versionadded:: 2.2
+        display_name_effect: Optional[:class:`NameEffect`]
+            The effect to use for your display name. Pass ``None`` to remove the effect.
+
+            .. versionadded:: 2.2
+        display_name_colors: Optional[List[:class:`Colour`]]
+            The colours to use for your display name. Pass ``None`` to remove the colours.
+
+            .. versionadded:: 2.2
+        nameplate_id: Optional[:class:`int`]
+            The ID of the nameplate to use. Pass ``None`` to remove the nameplate.
+
+            .. versionadded:: 2.2
+        nameplate_sku_id: Optional[:class:`int`]
+            The SKU ID of the nameplate to use. Pass ``None`` to remove the nameplate.
+
+            .. versionadded:: 2.2
+        avatar_decoration_id: Optional[:class:`int`]
+            The ID of the avatar decoration to use. Pass ``None`` to remove the avatar decoration.
+
+            .. versionadded:: 2.2
+        avatar_decoration_sku_id: Optional[:class:`int`]
+            The SKU ID of the avatar decoration to use. Pass ``None`` to remove the avatar decoration.
+
+            .. versionadded:: 2.2
+        pronouns: Optional[:class:`str`]
+            The pronouns to use for your profile. Pass ``None`` to remove the pronouns.
+
+            .. versionadded:: 2.2
 
         Raises
         ------
@@ -919,6 +963,9 @@ class ClientUser(BaseUser):
             `date_of_birth` field was not a :class:`datetime.date`.
             `accent_colo(u)r` parameter was not a :class:`Colour`.
             `primary_guild` parameter was not a :class:`discord.abc.Snowflake`.
+            `display_name_font` parameter was not a :class:`NameFont`.
+            `display_name_effect` parameter was not a :class:`NameEffect`.
+            `display_name_colors` parameter was not a list of :class:`Colour`.
 
         Returns
         ---------
@@ -1022,6 +1069,43 @@ class ClientUser(BaseUser):
                 primary_guild_enabled = primary_guild.identity_enabled
 
             data = await http.set_guild_identity(guild_id=primary_guild_id, enabled=primary_guild_enabled)
+
+        if display_name_font is not MISSING:
+            if display_name_font is None:
+                args['display_name_font_id'] = None
+            elif not isinstance(display_name_font, NameFont):
+                raise ValueError('`display_name_font` parameter was not a NameFont')
+            else:
+                args['display_name_font_id'] = display_name_font.value
+
+        if display_name_effect is not MISSING:
+            if display_name_effect is None:
+                args['display_name_effect_id'] = None
+            elif not isinstance(display_name_effect, NameEffect):
+                raise ValueError('`display_name_effect` parameter was not a NameEffect')
+            else:
+                args['display_name_effect_id'] = display_name_effect.value
+
+        if display_name_colors is not MISSING:
+            if display_name_colors is None:
+                args['display_name_colors'] = None
+            elif not isinstance(display_name_colors, list) or not all(isinstance(c, Colour) for c in display_name_colors):
+                raise ValueError('`display_name_colors` parameter was not a list of Colour')
+            else:
+                args['display_name_colors'] = [c.value for c in display_name_colors]
+
+        if nameplate_id is not MISSING:
+            args['nameplate_id'] = nameplate_id
+        if nameplate_sku_id is not MISSING:
+            args['nameplate_sku_id'] = nameplate_sku_id
+
+        if avatar_decoration_id is not MISSING:
+            args['avatar_decoration_id'] = avatar_decoration_id
+        if avatar_decoration_sku_id is not MISSING:
+            args['avatar_decoration_sku_id'] = avatar_decoration_sku_id
+
+        if pronouns is not MISSING:
+            args['pronouns'] = pronouns
 
         if args or data is None:
             data = await http.edit_profile(args)

--- a/discord/user.py
+++ b/discord/user.py
@@ -803,7 +803,6 @@ class ClientUser(BaseUser):
         global_name: Optional[str] = MISSING,
         avatar: Optional[Union[bytes, RecentAvatar]] = MISSING,
         avatar_description: str = MISSING,
-        avatar_decoration: Optional[bytes] = MISSING,
         password: str = MISSING,
         new_password: str = MISSING,
         email: str = MISSING,
@@ -870,15 +869,6 @@ class ClientUser(BaseUser):
             The description of the user's newly-uploaded avatar, used for displaying in recent avatars.
             Formatted typically as "{filename}, added {date}".
             Not applicable when setting a :class:`RecentAvatar`.
-        avatar_decoration: Optional[:class:`bytes`]
-            A :term:`py:bytes-like object` representing the image to upload.
-            Could be ``None`` to denote no avatar decoration.
-
-            .. versionadded:: 2.0
-            .. deprecated:: 2.2
-
-                This parameter is deprecated and will be removed in a future version.
-                Use ``avatar_decoration_id`` and ``avatar_decoration_sku_id`` instead.
         banner: :class:`bytes`
             A :term:`py:bytes-like object` representing the image to upload.
             Could be ``None`` to denote no banner.
@@ -993,12 +983,6 @@ class ClientUser(BaseUser):
 
         if avatar_description is not MISSING:
             args['avatar_description'] = avatar_description
-
-        if avatar_decoration is not MISSING:
-            if avatar_decoration is not None:
-                args['avatar_decoration'] = _bytes_to_base64_data(avatar_decoration)
-            else:
-                args['avatar_decoration'] = None
 
         if banner is not MISSING:
             if banner is not None:


### PR DESCRIPTION
## Summary

This adds support for a handful of profile customization features that weren't yet exposed in the library:

- `Member.guild_display_name_style` / `global_display_name_style` / `display_name_style` and the equivalent `ClientUser.display_name_style`, exposing the font, effect, and colors used for a user's display name at a guild level.
- `Member.guild_collectibles()` / `global_collectibles()` / `collectibles()`, returning owned collectibles (e.g. nameplates) at the guild or global level.
- New `Member.edit()` and `ClientUser.edit()` parameters: `display_name_font`, `display_name_effect`, `display_name_colours` (aliased as `display_name_colors`), `nameplate_sku_id`, `avatar_decoration_sku_id`, and `pronouns`.
- `Member.edit()` now also accepts a `RecentAvatar` for the `avatar` parameter, so a recent avatar can be set directly as a guild avatar, plus a new `avatar_description` parameter.
- `ClientUser.edit()`'s old `avatar_decoration` parameter is now removed in favor of the new `avatar_decoration_sku_id` parameter (the redundant `nameplate_id` and `avatar_decoration_id` parameters were dropped in favor of their `*_sku_id` equivalents).
- New `ClientUser.edit_profile()` method for editing profile metadata (bio, pronouns, banner, accent colour, theme colours, popout animation particle type, emoji, and profile effect) via the `PATCH /users/@me/profile` endpoint, returning the updated `ProfileMetadata`.
- Renamed `HTTPClient.edit_profile` to `edit_current_user` (to accurately reflect that it hits `PATCH /users/@me`) and added `edit_current_user_profile` for the new profile endpoint.

I haven't tested the nameplate and avatar decoration SKU parameters.

## General Info
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue (please put issue # in summary).
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)